### PR TITLE
Catch Exception When Opening an Already Connected Database

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -139,7 +139,12 @@ SQLRETURN Connect::SetConnection() {
 	config.SetOptionsByName(config_map);
 
 	bool cache_instance = database != IN_MEMORY_PATH;
-	dbc->env->db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
+
+    try {
+	    dbc->env->db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
+    } catch (std::exception &ex) {
+        return SetDiagnosticRecord(dbc, SQL_ERROR, "SQLDriverConnect", ex.what(), SQLStateType::ST_IM003, "");
+    }
 
 	if (!dbc->conn) {
 		dbc->conn = make_uniq<Connection>(*dbc->env->db);

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -143,7 +143,8 @@ SQLRETURN Connect::SetConnection() {
     try {
 	    dbc->env->db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
     } catch (std::exception &ex) {
-        return SetDiagnosticRecord(dbc, SQL_ERROR, "SQLDriverConnect", ex.what(), SQLStateType::ST_IM003, "");
+        ErrorData error(ex);
+        return SetDiagnosticRecord(dbc, SQL_ERROR, "SQLDriverConnect", error.Message(), SQLStateType::ST_IM003, "");
     }
 
 	if (!dbc->conn) {


### PR DESCRIPTION
Fix for: https://github.com/duckdb/duckdb-odbc/issues/4

The ODBC driver now correctly fills a diagnostic record and returns `SQL_ERROR` when a database is already connected in another process, and no longer throws an exception.