### PR TITLE
Alter `SQLColumns` to return SQL types instead of DuckDB types

### DIFF
--- a/src/api_info.cpp
+++ b/src/api_info.cpp
@@ -265,6 +265,8 @@ SQLSMALLINT ApiInfo::FindRelatedSQLType(duckdb::LogicalTypeId type_id) {
 		return SQL_DOUBLE;
 	case LogicalTypeId::LIST:
 		return SQL_VARCHAR;
+    case LogicalTypeId::BIT:
+        return SQL_BIT;
 	default:
 		return SQL_UNKNOWN_TYPE;
 	}

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -106,47 +106,47 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
                 101: 12 -- LIST -> SQL_VARCHAR
             } AS mapping,
             CASE
-            WHEN len(mapping[data_type_id]) != 0 THEN mapping[data_type_id][1]::BIGINT
-            ELSE data_type_id
+                WHEN len(mapping[data_type_id]) != 0 THEN mapping[data_type_id][1]::BIGINT
+                ELSE data_type_id
             END AS "DATA_TYPE",
             data_type "TYPE_NAME",
             CASE
-            WHEN data_type='DATE' THEN 12
-            WHEN data_type='TIME' THEN 15
-            WHEN data_type LIKE 'TIMESTAMP%' THEN 26
-            WHEN data_type='CHAR'
-                OR data_type='BOOLEAN' THEN 1
-            WHEN data_type='VARCHAR'
-                OR data_type='BLOB' THEN character_maximum_length
-            WHEN data_type LIKE '%INT%' THEN numeric_precision
-            WHEN data_type like 'DECIMAL%' THEN numeric_precision
-            WHEN data_type='FLOAT'
-                OR data_type='DOUBLE' THEN numeric_precision
-            ELSE NULL
+                WHEN data_type='DATE' THEN 12
+                WHEN data_type='TIME' THEN 15
+                WHEN data_type LIKE 'TIMESTAMP%' THEN 26
+                WHEN data_type='CHAR'
+                    OR data_type='BOOLEAN' THEN 1
+                WHEN data_type='VARCHAR'
+                    OR data_type='BLOB' THEN character_maximum_length
+                WHEN data_type LIKE '%INT%' THEN numeric_precision
+                WHEN data_type like 'DECIMAL%' THEN numeric_precision
+                WHEN data_type='FLOAT'
+                    OR data_type='DOUBLE' THEN numeric_precision
+                ELSE NULL
             END AS "COLUMN_SIZE",
             CASE
-            WHEN data_type='DATE' THEN 4
-            WHEN data_type='TIME' THEN 8
-            WHEN data_type LIKE 'TIMESTAMP%' THEN 8
-            WHEN data_type='CHAR'
-                OR data_type='BOOLEAN' THEN 1
-            WHEN data_type='VARCHAR'
-                OR data_type='BLOB' THEN 16
-            WHEN data_type LIKE '%TINYINT' THEN 1
-            WHEN data_type LIKE '%SMALLINT' THEN 2
-            WHEN data_type LIKE '%INTEGER' THEN 4
-            WHEN data_type LIKE '%BIGINT' THEN 8
-            WHEN data_type='HUGEINT' THEN 16
-            WHEN data_type='FLOAT' THEN 4
-            WHEN data_type='DOUBLE' THEN 8
-            ELSE NULL
+                WHEN data_type='DATE' THEN 4
+                WHEN data_type='TIME' THEN 8
+                WHEN data_type LIKE 'TIMESTAMP%' THEN 8
+                WHEN data_type='CHAR'
+                    OR data_type='BOOLEAN' THEN 1
+                WHEN data_type='VARCHAR'
+                    OR data_type='BLOB' THEN 16
+                WHEN data_type LIKE '%TINYINT' THEN 1
+                WHEN data_type LIKE '%SMALLINT' THEN 2
+                WHEN data_type LIKE '%INTEGER' THEN 4
+                WHEN data_type LIKE '%BIGINT' THEN 8
+                WHEN data_type='HUGEINT' THEN 16
+                WHEN data_type='FLOAT' THEN 4
+                WHEN data_type='DOUBLE' THEN 8
+                ELSE NULL
             END AS "BUFFER_LENGTH",
             numeric_scale "DECIMAL_DIGITS",
             numeric_precision_radix "NUM_PREC_RADIX",
             CASE is_nullable
-            WHEN FALSE THEN 0
-            WHEN TRUE THEN 1
-            ELSE 2
+                WHEN FALSE THEN 0
+                WHEN TRUE THEN 1
+                ELSE 2
             END AS "NULLABLE",
             NULL "REMARKS",
             column_default "COLUMN_DEF",

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -84,7 +84,7 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
             TABLE_NAME "TABLE_NAME",
             COLUMN_NAME "COLUMN_NAME",
             MAP {
-                'BOOL': 1, -- SQL_CHAR
+                'BOOLEAN': 1, -- SQL_CHAR
                 'TINYINT': -6, -- SQL_TINYINT
                 'UTINYINT': -6, -- SQL_TINYINT
                 'SMALLINT': 5, -- SQL_SMALLINT

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -82,31 +82,32 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
             SELECT NULL "TABLE_CAT",
             SCHEMA_NAME "TABLE_SCHEM",
             TABLE_NAME "TABLE_NAME",
-            COLUMN_NAME "COLUMN_NAME", MAP {
-                10: 1, -- BOOL -> SQL_CHAR
-                11: -6, -- TINYINT -> SQL_TINYINT
-                28: -6, -- UTINYINT -> SQL_TINYINT
-                12: 5, -- SMALLINT -> SQL_SMALLINT
-                29: 5, -- USMALLINT -> SQL_SMALLINT
-                13: 4, -- INTEGER -> SQL_INTEGER
-                30: 4, -- UINTEGER -> SQL_INTEGER
-                14: -5, -- BIGINT -> SQL_BIGINT
-                31: -5, -- UBIGINT -> SQL_BIGINT
-                22: 6, -- FLOAT -> SQL_FLOAT
-                50: 8, -- HUGEINT -> SQL_DOUBLE
-                23: 8, -- DOUBLE -> SQL_DOUBLE
-                15: 91, -- DATE -> SQL_TYPE_DATE
-                19: 93, -- TIMESTAMP -> SQL_TYPE_TIMESTAMP
-                16: 92, -- TIME -> SQL_TYPE_TIME
-                25: 12, -- VARCHAR -> SQL_VARCHAR
-                26: -3, -- BLOB -> SQL_VARBINARY
-                27: 10, -- INTERVAL -> SQL_INTERVAL
-                21: 8, -- DECIMAL -> SQL_DOUBLE
-                36: -7, -- BIT -> SQL_BIT
-                101: 12 -- LIST -> SQL_VARCHAR
+            COLUMN_NAME "COLUMN_NAME",
+            MAP {
+                'BOOL': 1, -- SQL_CHAR
+                'TINYINT': -6, -- SQL_TINYINT
+                'UTINYINT': -6, -- SQL_TINYINT
+                'SMALLINT': 5, -- SQL_SMALLINT
+                'USMALLINT': 5, -- SQL_SMALLINT
+                'INTEGER': 4, -- SQL_INTEGER
+                'UINTEGER': 4, -- SQL_INTEGER
+                'BIGINT': -5, -- SQL_BIGINT
+                'UBIGINT': -5, -- SQL_BIGINT
+                'FLOAT': 6, -- SQL_FLOAT
+                'HUGEINT': 8, -- SQL_DOUBLE
+                'DOUBLE': 8, -- SQL_DOUBLE
+                'DATE': 91, -- SQL_TYPE_DATE
+                'TIMESTAMP': 93, -- SQL_TYPE_TIMESTAMP
+                'TIME': 92, -- SQL_TYPE_TIME
+                'VARCHAR': 12, -- SQL_VARCHAR
+                'BLOB': -3, -- SQL_VARBINARY
+                'INTERVAL': 10, -- SQL_INTERVAL
+                'DECIMAL': 8, -- SQL_DOUBLE
+                'BIT': -7, -- SQL_BIT
+                'LIST': 12 -- SQL_VARCHAR
             } AS mapping,
             CASE
-                WHEN len(mapping[data_type_id]) != 0 THEN mapping[data_type_id][1]::BIGINT
+                WHEN len(mapping[data_type]) != 0 THEN mapping[data_type][1]::BIGINT
                 ELSE data_type_id
             END AS "DATA_TYPE",
             data_type "TYPE_NAME",
@@ -151,7 +152,7 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
             NULL "REMARKS",
             column_default "COLUMN_DEF",
             CASE
-                WHEN len(mapping[data_type_id]) != 0 THEN mapping[data_type_id][1]::BIGINT
+                WHEN len(mapping[data_type]) != 0 THEN mapping[data_type][1]::BIGINT
                 ELSE data_type_id
             END AS "SQL_DATA_TYPE",
             CASE

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -205,13 +205,13 @@ static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_m
 	}
 
 	std::vector<std::array<std::string, 4>> expected_data = {
-	    {"bool_table", "id", "13", "INTEGER"},      {"bool_table", "t", "25", "VARCHAR"},
-	    {"bool_table", "b", "10", "BOOLEAN"},       {"bytea_table", "id", "13", "INTEGER"},
-	    {"bytea_table", "t", "26", "BLOB"},         {"interval_table", "id", "13", "INTEGER"},
-	    {"interval_table", "iv", "27", "INTERVAL"}, {"interval_table", "d", "25", "VARCHAR"},
-	    {"lo_test_table", "id", "13", "INTEGER"},   {"lo_test_table", "large_data", "26", "BLOB"},
-	    {"test_table_1", "id", "13", "INTEGER"},    {"test_table_1", "t", "25", "VARCHAR"},
-	    {"test_view", "id", "13", "INTEGER"},       {"test_view", "t", "25", "VARCHAR"}};
+	    {"bool_table", "id", "4", "INTEGER"},      {"bool_table", "t", "12", "VARCHAR"},
+	    {"bool_table", "b", "1", "BOOLEAN"},       {"bytea_table", "id", "4", "INTEGER"},
+	    {"bytea_table", "t", "-3", "BLOB"},         {"interval_table", "id", "4", "INTEGER"},
+	    {"interval_table", "iv", "10", "INTERVAL"}, {"interval_table", "d", "12", "VARCHAR"},
+	    {"lo_test_table", "id", "4", "INTEGER"},   {"lo_test_table", "large_data", "-3", "BLOB"},
+	    {"test_table_1", "id", "4", "INTEGER"},    {"test_table_1", "t", "12", "VARCHAR"},
+	    {"test_view", "id", "4", "INTEGER"},       {"test_view", "t", "12", "VARCHAR"}};
 
 	for (int i = 0; i < expected_data.size(); i++) {
 		SQLRETURN ret = SQLFetch(hstmt);


### PR DESCRIPTION
Currently `SQLColumns` returns the internal DuckDB type in the `DATA_TYPE` and `SQL_DATA_TYPE` columns.  Although this is supported by [ODBC Documentation](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolumns-function?view=sql-server-ver16): 
> SQL data type, as it appears in the SQL_DESC_TYPE record field in the IRD. This can be an ODBC SQL data type or a driver-specific SQL data type

The behavior is inconsistent with `SQLDescribeCol` which returns the SQL type.

This PR changes that and now both functions return SQL types.

Resolves https://github.com/duckdb/duckdb-odbc/issues/8.