### PR TITLE
Fix: Don't pass default schema name to schema filter in SQLTables

### DIFF
--- a/src/statement/statement.cpp
+++ b/src/statement/statement.cpp
@@ -389,8 +389,7 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQ
 
 	// String search pattern for schema name
 	auto schema_n = OdbcUtils::ReadString(schema_name, name_length2);
-	string schema_filter = OdbcUtils::ParseStringFilter("\"TABLE_SCHEM\"", schema_n, hstmt->dbc->sql_attr_metadata_id,
-	                                                    string(DEFAULT_SCHEMA));
+	string schema_filter = OdbcUtils::ParseStringFilter("\"TABLE_SCHEM\"", schema_n, hstmt->dbc->sql_attr_metadata_id);
 
 	// String search pattern for table name
 	auto table_n = OdbcUtils::ReadString(table_name, name_length3);

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -200,6 +200,13 @@ void InitializeDatabase(HSTMT &hstmt) {
 	EXEC_SQL(hstmt, "CREATE VIEW test_view AS SELECT * FROM test_table_1;");
 
 	EXEC_SQL(hstmt, "CREATE TABLE lo_test_table (id int4, large_data blob);");
+
+	EXEC_SQL(hstmt, "CREATE SCHEMA IF NOT EXISTS ducks;");
+	EXEC_SQL(hstmt, "DROP TABLE IF EXISTS ducks.test_table_2;");
+	EXEC_SQL(hstmt, "CREATE TABLE ducks.test_table_2 (id integer PRIMARY KEY, t varchar(20));");
+	EXEC_SQL(hstmt, "INSERT INTO ducks.test_table_2 VALUES (1, 'quack');");
+	EXEC_SQL(hstmt, "INSERT INTO ducks.test_table_2 VALUES (2, 'quack quack');");
+	EXEC_SQL(hstmt, "INSERT INTO ducks.test_table_2 VALUES (3, 'quack quack quack');");
 }
 
 std::map<SQLSMALLINT, SQLULEN> InitializeTypesMap() {


### PR DESCRIPTION
Fixes #25 