### PR TITLE
Update CMakeLists.txt.in 

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -24,7 +24,7 @@ if(ODBC_FOUND)
 
   if(WIN32)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-#    add_subdirectory(winsetup)
+    add_subdirectory(winsetup)
     list(APPEND LINK_LIB_LIST $<$<PLATFORM_ID:Windows>:odbccp32>)
     list(APPEND LINK_LIB_LIST
          $<$<PLATFORM_ID:Windows>:legacy_stdio_definitions>)


### PR DESCRIPTION
Update `CMakeLists.txt.in` so that `add_subdirectory(winsetup)` is no longer automatically commented out when the vendor is updated. 