### PR TITLE
Update ODBC.yml to use windows-2019

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -111,7 +111,7 @@ jobs:
 
   odbc-windows-amd64:
     name: ODBC Windows (amd64)
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: odbc-linux-amd64
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I have NOT tried this, sort of relying on CI for now.

Connected to this duckdb's PR https://github.com/duckdb/duckdb/pull/13883, and related failures. I think also ODBC driver would need to be built on an older Windows machine for it to be compatible with say Windows Server 2019.