### PR TITLE
Fix parsing conn string with a trailing semicolon

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -80,13 +80,11 @@ SQLRETURN Connect::ParseInputStr() {
 		input_str.erase(0, row_pos + 1);
 	}
 
-	if (input_str.empty()) {
-		return SQL_SUCCESS;
-	}
-
-	SQLRETURN ret = FindKeyValPair(input_str);
-	if (ret != SQL_SUCCESS) {
-		return ret;
+	if (!input_str.empty()) {
+		SQLRETURN ret = FindKeyValPair(input_str);
+		if (ret != SQL_SUCCESS) {
+			return ret;
+		}
 	}
 
 	// Extract the DSN from the config map as it is needed to read from the .odbc.ini file

--- a/test/tests/connect_with_ini.cpp
+++ b/test/tests/connect_with_ini.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Test SQLConnect with Ini File", "[odbc]") {
 }
 
 // Connect to the database using the ini file when connection string
-// has extra options and a trailing comma
+// has extra options and a trailing semicolon
 TEST_CASE("Test SQLConnect with Ini File with extra options", "[odbc]") {
 #if defined ODBC_LINK_ODBCINST || defined WIN32
 	// Connect to the database using the ini file

--- a/test/tests/connect_with_ini.cpp
+++ b/test/tests/connect_with_ini.cpp
@@ -26,3 +26,23 @@ TEST_CASE("Test SQLConnect with Ini File", "[odbc]") {
 	DISCONNECT_FROM_DATABASE(env, dbc);
 #endif
 }
+
+// Connect to the database using the ini file when connection string
+// has extra options and a trailing comma
+TEST_CASE("Test SQLConnect with Ini File with extra options", "[odbc]") {
+#if defined ODBC_LINK_ODBCINST || defined WIN32
+	// Connect to the database using the ini file
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+	DRIVER_CONNECT_TO_DATABASE(env, dbc, "DSN=DuckDB;allow_unsigned_extensions=false;");
+
+	// Check that the database is set
+	CheckDatabase(dbc);
+
+	// Check that allow_unsigned_extensions is set from connection string
+	CheckConfig(dbc, "allow_unsigned_extensions", "false");
+
+	// Disconnect from the database
+	DISCONNECT_FROM_DATABASE(env, dbc);
+#endif
+}


### PR DESCRIPTION
Hi,

This PR fixes the connection string parsing for cases, when such string ends with a semicolon.

When connection string includes a trailing semicolon, existing impl in `Connect::ParseInputStr` was doing [an early exit](https://github.com/duckdb/duckdb-odbc/blob/935c2c9bcd760dae3bcf5f09ac1df11844f39b6c/src/connect/connect.cpp#L84) without [setting DSN value](https://github.com/duckdb/duckdb-odbc/blob/935c2c9bcd760dae3bcf5f09ac1df11844f39b6c/src/connect/connect.cpp#L93) to `dbc->dsn`. Because of this DSN was not used and default `:memory:` instance was created.

The problem is not OS specific, but was happening on Windows all the time because Windows ODBC Driver Manager is appending semicolon to the passed connection string when calling `SQLDriverConnect`.

Testing: `test_connect_odbc` was extended to cover the trailing semicolon and also parameters overriding in connection string.

Fixes: #29, #48

Edit: typo in a commit mesage: `%s/comma/semicolon/g`.