### PR TITLE
Fix args passing in odbc_install non-admin mode

### DIFF
--- a/winsetup/install.c
+++ b/winsetup/install.c
@@ -260,10 +260,20 @@ void ElevatePrivilegesAsAdmin(char **parameters) {
 }
 
 void CopyParameters(int argc, char **argv, char **parameters) {
-	size_t alloc_size, last_alloc_pos = 0;
+	size_t len = 0;
+
 	for (int i = 1; i < argc; i++) {
-		alloc_size = strlen(argv[i]) + 1;
-		*parameters = (char *)realloc(*parameters, alloc_size);
+		len += strlen(argv[i]);
+		if ((i + 1) != argc) {
+			// space between parameters
+			len += 1; 
+		}
+	}
+
+	*parameters = (char *)malloc(len + 1);
+	(*parameters)[0] = '\0';
+ 
+	for (int i = 1; i < argc; i++) {
 		strcat(*parameters, argv[i]);
 		if ((i + 1) != argc) {
 			strcat(*parameters, " ");


### PR DESCRIPTION
When `odbc_install.exe` is launched under OS user without Administrator permissions, [then elevated priviliges are requested](https://github.com/duckdb/duckdb-odbc/blob/935c2c9bcd760dae3bcf5f09ac1df11844f39b6c/winsetup/install.c#L281) (UAC screen displayed) and `odbc_install.exe` is [launched again](https://github.com/duckdb/duckdb-odbc/blob/935c2c9bcd760dae3bcf5f09ac1df11844f39b6c/winsetup/install.c#L242) using 'runas' utility. Original arguments ('/CI', '/Uninstall') are copied into a buffer to pass it to 'ShellExecuteEx'. This copy routine was buggy and a string with partially uninitialized memory was passed instead.

This change calculates the buffer size for all arguments and allocates memory for it once without using problematic `realloc`.

Testing: because of the UAC screen required to reproduce this, I cannot see an easy way to automate it, so there is no test.

Fixes: #36