### PR TITLE
Fix conn string parsing with unsupported options

### DIFF
--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -74,7 +74,7 @@ SQLRETURN Connect::ParseInputStr() {
 	while ((row_pos = input_str.find(ROW_DEL)) != std::string::npos) {
 		row = input_str.substr(0, row_pos);
 		SQLRETURN ret = FindKeyValPair(row);
-		if (ret != SQL_SUCCESS) {
+		if (!SetSuccessWithInfo(ret)) {
 			return ret;
 		}
 		input_str.erase(0, row_pos + 1);
@@ -82,7 +82,7 @@ SQLRETURN Connect::ParseInputStr() {
 
 	if (!input_str.empty()) {
 		SQLRETURN ret = FindKeyValPair(input_str);
-		if (ret != SQL_SUCCESS) {
+		if (!SetSuccessWithInfo(ret)) {
 			return ret;
 		}
 	}
@@ -90,7 +90,7 @@ SQLRETURN Connect::ParseInputStr() {
 	// Extract the DSN from the config map as it is needed to read from the .odbc.ini file
 	dbc->dsn = seen_config_options["dsn"] ? config_map["dsn"].ToString() : "";
 
-	return SQL_SUCCESS;
+	return GetSuccessWithInfo() ? SQL_SUCCESS_WITH_INFO : SQL_SUCCESS;
 }
 
 SQLRETURN Connect::ReadFromIniFile() {

--- a/test/tests/connect.cpp
+++ b/test/tests/connect.cpp
@@ -127,6 +127,9 @@ static void TestSettingConfigs() {
 
 	SetConfig("Database=" + GetTesterDirectory() + "test.duckdb;" + "access_mode=READ_WRITE", "access_mode",
 	          "READ_WRITE");
+
+	// Test handling unsupported connection string options
+	SetConfig("unsupported_option_1=value_1;allow_unsigned_extensions=true;", "allow_unsigned_extensions", "true");
 }
 
 TEST_CASE("Test SQLConnect and SQLDriverConnect", "[odbc]") {

--- a/test/tests/connect_with_ini.cpp
+++ b/test/tests/connect_with_ini.cpp
@@ -46,3 +46,20 @@ TEST_CASE("Test SQLConnect with Ini File with extra options", "[odbc]") {
 	DISCONNECT_FROM_DATABASE(env, dbc);
 #endif
 }
+
+// Connect to the database using the ini file checking that DSN is set correctly
+// when unsupported options are present in the connection string
+TEST_CASE("Test SQLConnect with Ini File with unsupported options", "[odbc]") {
+#if defined ODBC_LINK_ODBCINST || defined WIN32
+	// Connect to the database using the ini file
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+	DRIVER_CONNECT_TO_DATABASE(env, dbc, "DSN=DuckDB;unsupported_option_1=value_1;");
+
+	// Check that the database is set
+	CheckDatabase(dbc);
+
+	// Disconnect from the database
+	DISCONNECT_FROM_DATABASE(env, dbc);
+#endif
+}


### PR DESCRIPTION
The ODBC specification does not mandate how the driver should deal with unsupported options specified by client in the connection string ([link](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/driver-specific-connection-information?view=sql-server-ver16)).

When encountering an unsupported option, DuckDB driver registers a diagnostic message in a format: `Invalid keyword: <option_name>`, that can be fetched by client using `SQLGetDiagRec` function, and returns `SQL_SUCCESS_WITH_INFO` instead of `SQL_SUCCESS`.

This is a reasonable approach, but there is inconsistent error handling in its implementation in [Connect::ParseInputStr](https://github.com/duckdb/duckdb-odbc/blob/8b9b9117234f8bd2468ccb19701a27d7ac2d3e87/src/connect/connect.cpp#L77). It only checks for `SQL_SUCCESS` and treats `SQL_SUCCESS_WITH_INFO` as an error. This causes the early exit from this function that prevents subsequent options in the connection string to be processed. It also [prevents the DSN name to be set on the connection](https://github.com/duckdb/duckdb-odbc/blob/8b9b9117234f8bd2468ccb19701a27d7ac2d3e87/src/connect/connect.cpp#L90) (even when the DSN option comes before the unsupported one).

To fix this it is proposed to check for both `SQL_SUCCESS` and `SQL_SUCCESS_WITH_INFO` and only do the early exit if some other error code is returned by [FindKeyValPair routine](https://github.com/duckdb/duckdb-odbc/blob/8b9b9117234f8bd2468ccb19701a27d7ac2d3e87/src/connect/connect.cpp#L39).

Testing: tests are included for a common option and for the DSN option.

Fixes: #59