### PR TITLE
Ignore UID and PWD options from Excel

### DIFF
--- a/include/connect.hpp
+++ b/include/connect.hpp
@@ -34,10 +34,11 @@ public:
 	bool GetSuccessWithInfo() const {
 		return success_with_info;
 	}
-	// Ignore keys for use with Power Query
-	std::vector<std::string> PQIgnoreKeys = {"driver", "trusted_connection"};
 
 private:
+	// Ignore keys automatically added by Excel, PowerBI and other popular ODBC clients
+	static const std::vector<std::string> IGNORE_KEYS;
+
 	OdbcHandleDbc *dbc;
 	std::string input_str;
 	bool success_with_info = false;

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -12,6 +12,13 @@ using namespace duckdb;
 //! The database instance cache, used so that multiple connections to the same file point to the same database object
 DBInstanceCache instance_cache;
 
+const std::vector<std::string> Connect::IGNORE_KEYS = {
+    "driver",             // can be used by any client connecting without DSN
+    "trusted_connection", // set by Power Query Connector by MotherDuck
+    "uid",                // used by default for ODBC sources in Excel
+    "pwd",                // likewise uid
+};
+
 bool Connect::SetSuccessWithInfo(SQLRETURN ret) {
 	if (!SQL_SUCCEEDED(ret)) {
 		return false;
@@ -49,7 +56,7 @@ SQLRETURN Connect::FindKeyValPair(const std::string &row) {
 	std::string key_candidate = StringUtil::Lower(row.substr(0, val_pos));
 
 	// Check if the key can be ignored
-	if (std::find(PQIgnoreKeys.begin(), PQIgnoreKeys.end(), key_candidate) != PQIgnoreKeys.end()) {
+	if (std::find(IGNORE_KEYS.begin(), IGNORE_KEYS.end(), key_candidate) != IGNORE_KEYS.end()) {
 		return SQL_SUCCESS;
 	}
 

--- a/test/tests/connect.cpp
+++ b/test/tests/connect.cpp
@@ -25,8 +25,9 @@ void ConnectWithoutDSN(SQLHANDLE &env, SQLHANDLE &dbc) {
 
 // Connect to a database with extra keywords provided by Power Query SDK
 void ConnectWithPowerQuerySDK(SQLHANDLE &env, SQLHANDLE &dbc) {
-	std::string conn_str = "DRIVER={DuckDB Driver};database=" + GetTesterDirectory() +
-	                       +";custom_user_agent=powerbi/v0.0(DuckDB);Trusted_Connection=yes;";
+	std::string conn_str = "DRIVER={DuckDB Driver};database=" + GetTesterDirectory() + ";" +
+	                       "custom_user_agent=powerbi/v0.0(DuckDB);" + "Trusted_Connection=yes;" + "UID=user1;" +
+	                       "PWD=password1;" + "allow_unsigned_extensions=true;";
 	SQLCHAR str[1024];
 	SQLSMALLINT strl;
 
@@ -40,6 +41,8 @@ void ConnectWithPowerQuerySDK(SQLHANDLE &env, SQLHANDLE &dbc) {
 
 	EXECUTE_AND_CHECK("SQLDriverConnect", SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS,
 	                  str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
+
+	CheckConfig(dbc, "allow_unsigned_extensions", "true");
 }
 
 // Connect with incorrect params


### PR DESCRIPTION
When the ODBC data source is used from Excel/Power Query, additional options may be added to connection string automatically without showing them to user. It was discovered in #58 that `UID` and `PWD` options are added when user has credentials registered for this DSN in Excel.

DuckDB driver does not recognize these options and currently cannot process them properly (see #59 for details). However the driver knows about possible `trusted_connection` Excel/Power Query option and ignores it successfully. It is proposed to also add `UID` and `PWD` to the existing ignore list.

In the light of #60, that fixes the handling for unsupported options, this change is not strictly necessary, but it still may be better to consistently ignore all unneeded Excel/Power Query options and to not register diagnostic messages for them.

Testing: existing Excel/Power Query ignore list test is extended to include new options.

Fixes: #58