### PR TITLE
Fix SQLGetDiagRec for length-only calls

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -269,6 +269,16 @@ SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSM
 	}
 
 	std::string msg = diag_record.GetMessage(buffer_length);
+
+	if (message_text == nullptr) {
+		if (text_length_ptr) {
+			size_t len = msg.length();
+			size_t max_len = std::numeric_limits<SQLSMALLINT>::max();
+			*text_length_ptr = static_cast<SQLSMALLINT>(len <= max_len ? len : max_len);
+		}
+		return SQL_SUCCESS_WITH_INFO;
+	}
+
 	OdbcUtils::WriteString(msg, message_text, buffer_length, text_length_ptr);
 
 	if (text_length_ptr) {
@@ -278,10 +288,6 @@ SQLRETURN SQL_API SQLGetDiagRec(SQLSMALLINT handle_type, SQLHANDLE handle, SQLSM
 			hdl->odbc_diagnostic->AddNewRecIdx(rec_idx);
 			return SQL_SUCCESS_WITH_INFO;
 		}
-	}
-
-	if (message_text == nullptr) {
-		return SQL_SUCCESS_WITH_INFO;
 	}
 
 	return SQL_SUCCESS;

--- a/test/tests/diagnostics.cpp
+++ b/test/tests/diagnostics.cpp
@@ -80,6 +80,12 @@ TEST_CASE("Test SQLGetDiagRec (returns diagnostic record)", "[odbc]") {
 	REQUIRE(!first_endtran_state.compare(second_endtran_state));
 	REQUIRE(!first_endtran_message.compare(second_endtran_message));
 
+	// Check that TextLengthPtr is set to the actual length when the MessageText specified as NULL
+	SQLSMALLINT text_length;
+	ret = SQLGetDiagRec(SQL_HANDLE_DBC, dbc, 1, nullptr, nullptr, nullptr, 0, &text_length);
+	REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+	REQUIRE(first_endtran_message.length() == static_cast<size_t>(text_length));
+
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
 	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);


### PR DESCRIPTION
According to [ODBC spec](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdiagrec-function?view=sql-server-ver16):

> If `MessageText` is `NULL`, `TextLengthPtr` will still return the
> total number of characters (excluding the null-termination character
> for character data) available to return in the buffer pointed to by
> `MessageText`.

Such length-only calls are actually used by the Windows ODBC Driver Manager. Currently messages are returned in garbled form on Windows.

This change adds the logic to set the `TextLengthPtr` to the actual message length when the `MessageText` is specified as `NULL`.

Note: the impl still can be improved to handle partial message reads better (cover existing TODO there).

Testing: existing test is extended to cover this scenario.

Fixes: #56