### PR TITLE
Update isql tests after duckdb/duckdb#15864

### DIFF
--- a/test/isql-test.py
+++ b/test/isql-test.py
@@ -142,9 +142,9 @@ test(
 
 test('SELECT MIN(t) FROM timestamp;', out='2007-01-01 00:00:01')
 test('SELECT MAX(t) FROM timestamp;', out='2008-02-01 00:00:01')
+test('SELECT AVG(t) FROM timestamp', out="2007-11-14 11:44:19.142857")
 
 test('SELECT SUM(t) FROM timestamp', err="[ISQL]ERROR")
-test('SELECT AVG(t) FROM timestamp', err="[ISQL]ERROR")
 test('SELECT t+t FROM timestamp', err="[ISQL]ERROR")
 test('SELECT t*t FROM timestamp', err="[ISQL]ERROR")
 test('SELECT t/t FROM timestamp', err="[ISQL]ERROR")


### PR DESCRIPTION
isql tests are updated with recent changes from [upstream test_timestamp.test](https://github.com/duckdb/duckdb/pull/15864/commits/1e404813c9ec1ebe47e4d1b4dccfd86ad978ba7d#diff-bc3802a103e8d18343774ae2fa514c24839d496f1b51aff9dac01208358c3cae). This fixes the [CI failures](https://github.com/duckdb/duckdb-odbc/actions/runs/13402871785/job/37438328140) that started happening after duckdb/duckdb#15864 changes were integrated.

Fixes: #64