### PR TITLE
Use windows-2019 instead of windows-latest on CI

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -100,7 +100,7 @@ jobs:
 
   odbc-windows-amd64:
     name: ODBC Windows (amd64)
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: odbc-linux-amd64
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,10 @@ set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} src/duckdb/ub_src_catalog.cpp src/duckd
 
 add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES}  duckdb_odbc.def)
 
+if(WIN32)
+  target_compile_options(duckdb_odbc PRIVATE /bigobj)
+endif()
+
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")
 target_link_libraries(duckdb_odbc ${LINK_LIB_LIST} )
 target_link_libraries(duckdb_odbc Threads::Threads ${DUCKDB_SYSTEM_LIBS})

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -53,6 +53,10 @@ set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} ${SOURCE_FILES})
 
 add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES}  duckdb_odbc.def)
 
+if(WIN32)
+  target_compile_options(duckdb_odbc PRIVATE /bigobj)
+endif()
+
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")
 target_link_libraries(duckdb_odbc ${LINK_LIB_LIST} ${LIBRARY_FILES})
 target_link_libraries(duckdb_odbc Threads::Threads ${DUCKDB_SYSTEM_LIBS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,11 @@ add_executable(
 add_executable(test_connection_odbc common.cpp tests/connect_with_ini.cpp
                                     connect_helpers.cpp)
 
+if(WIN32)
+  target_compile_options(test_odbc PRIVATE /bigobj)
+  target_compile_options(test_connection_odbc PRIVATE /bigobj)
+endif()
+
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
   # System.Data.ODBC tests Visual Studio Generator due to use of C++ CLI and
   # .NET.

--- a/test/tests/dotnet/CMakeLists.txt
+++ b/test/tests/dotnet/CMakeLists.txt
@@ -24,3 +24,4 @@ list(APPEND VS_DOTNET_REFERENCES "System.Xml.Linq")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DOTNET_REFERENCES
                                                  "${VS_DOTNET_REFERENCES}")
+set_target_properties(${PROJECT_NAME} PROPERTIES DOTNET_TARGET_FRAMEWORK net472)


### PR DESCRIPTION
This change is a continuation of duckdb/duckdb#13883 and #34. While the #24 appeared to be unrelated, it still makes sense to use older Windows version on CI.