### PR TITLE
Add scripts for test_connection_odbc on Windows

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -147,9 +147,7 @@ jobs:
       - name: Setup Register For Connection Tests
         shell: bash
         run: |
-          REG ADD "HKCU\SOFTWARE\ODBC\ODBC.INI\DuckDB" //v database //t REG_SZ //d "/d/a/duckdb-odbc/duckdb-odbc/test/sql/storage_version/storage_version.db"
-          REG ADD "HKCU\SOFTWARE\ODBC\ODBC.INI\DuckDB" //v access_mode //t REG_SZ //d "READ_ONLY"
-          REG ADD "HKCU\SOFTWARE\ODBC\ODBC.INI\DuckDB" //v allow_unsigned_extensions //t REG_SZ //d "true"
+          python ./scripts/create_ini_reg.py
           echo "----------------------------------------------------------------"
           Reg Query "HKCU\SOFTWARE\ODBC\ODBC.INI\DuckDB"
 

--- a/scripts/create_ini_reg.py
+++ b/scripts/create_ini_reg.py
@@ -1,0 +1,39 @@
+import os, subprocess
+from os import path
+
+script_dir = path.dirname(path.realpath(__file__))
+project_dir = path.dirname(script_dir)
+reg_exe = path.join(os.environ["WINDIR"], "System32", "reg.exe")
+
+subprocess.run(
+    [
+        reg_exe,
+        "add",
+        "HKCU\\SOFTWARE\\ODBC\\ODBC.INI\\DuckDB",
+        "/v",
+        "database",
+        "/t",
+        "REG_SZ",
+        "/d",
+        path.join(project_dir, "test", "sql", "storage_version", "storage_version.db"),
+    ],
+    check=True,
+)
+subprocess.run(
+    [reg_exe, "add", "HKCU\\SOFTWARE\\ODBC\\ODBC.INI\\DuckDB", "/v", "access_mode", "/t", "REG_SZ", "/d", "READ_ONLY"],
+    check=True,
+)
+subprocess.run(
+    [
+        reg_exe,
+        "add",
+        "HKCU\\SOFTWARE\\ODBC\\ODBC.INI\\DuckDB",
+        "/v",
+        "allow_unsigned_extensions",
+        "/t",
+        "REG_SZ",
+        "/d",
+        "true",
+    ],
+    check=True,
+)

--- a/scripts/delete_ini_reg.py
+++ b/scripts/delete_ini_reg.py
@@ -1,0 +1,7 @@
+import os, subprocess
+from os import path
+
+subprocess.run(
+    [path.join(os.environ["WINDIR"], "System32", "reg.exe"), "delete", "HKCU\\SOFTWARE\\ODBC\\ODBC.INI\\DuckDB", "/f"],
+    check=True,
+)


### PR DESCRIPTION
`test_connection_odbc` requires the DSN setup either in an .ini file (on Linux and Mac) or in Windows registry.

This change adds Pyton scripts that can be used for DSN setup on Windows the same way as existing Bash scripts are used on Linux/Mac.

Testing: no functional changes, no new tests.

Fixes: #47