### PR TITLE
Do not link libodbc into test runners

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,5 +40,5 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
   add_subdirectory(tests/dotnet)
 endif()
 
-target_link_libraries(test_odbc duckdb_odbc ODBC::ODBC)
-target_link_libraries(test_connection_odbc duckdb_odbc ODBC::ODBC)
+target_link_libraries(test_odbc duckdb_odbc)
+target_link_libraries(test_connection_odbc duckdb_odbc)


### PR DESCRIPTION
Currently test runners link in both `libduckdb_odbc` and `libodbc`. Perhaps I am missing something, but I cannot understand how this can be correct, as these libs define the same ODBC API symbols. This leads to interesting issues when signatures in these libs differ slightly.

Proposed change removes the `libodbc` from test runners.

Testing: no functional changes, no new tests.