### PR TITLE
Support importing tables into MS Access

### DIFF
--- a/include/duckdb_odbc.hpp
+++ b/include/duckdb_odbc.hpp
@@ -106,6 +106,11 @@ struct OdbcBoundCol {
 	SQLLEN *strlen_or_ind;
 };
 
+struct OdbcStmtClientAttrs {
+public:
+	SQLULEN max_len = 0;
+};
+
 struct OdbcHandleStmt : public OdbcHandle {
 public:
 	explicit OdbcHandleStmt(OdbcHandleDbc *dbc_p);
@@ -127,6 +132,9 @@ public:
 	bool open;
 	SQLULEN retrieve_data = SQL_RD_ON;
 	SQLULEN *rows_fetched_ptr;
+
+	// statement attributes required by clients but not used by the engine
+	OdbcStmtClientAttrs client_attrs;
 
 	// fetcher
 	duckdb::unique_ptr<OdbcFetch> odbc_fetcher;

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -11,6 +11,9 @@ using duckdb::vector;
 using std::string;
 
 string OdbcUtils::ReadString(const SQLPOINTER ptr, const SQLSMALLINT len) {
+	if (ptr == nullptr) {
+		return std::string();
+	}
 	return len == SQL_NTS ? string((const char *)ptr) : string((const char *)ptr, (size_t)len);
 }
 

--- a/src/connect/connection.cpp
+++ b/src/connect/connection.cpp
@@ -13,6 +13,9 @@
 #define SQL_DTC_TRANSACTION_COST 1750
 #define SQL_RETURN_ESCAPE_CLAUSE 180
 
+// Set by MS Access (Jet engine)
+#define VENDOR_MSJET 30002
+
 using duckdb::OdbcUtils;
 using duckdb::SQLStateType;
 using std::ptrdiff_t;
@@ -129,6 +132,7 @@ SQLRETURN SQL_API SQLSetConnectAttr(SQLHDBC connection_handle, SQLINTEGER attrib
 	case SQL_ATTR_LOGIN_TIMEOUT:
 	case SQL_ATTR_ODBC_CURSORS:
 	case SQL_ATTR_PACKET_SIZE:
+	case VENDOR_MSJET:
 		return SQL_SUCCESS;
 	default:
 		break;

--- a/src/empty_stubs.cpp
+++ b/src/empty_stubs.cpp
@@ -12,21 +12,6 @@ SQLRETURN SQL_API SQLNativeSql(SQLHDBC connection_handle, SQLCHAR *in_statement_
 	return SQL_ERROR;
 }
 
-SQLRETURN SQL_API SQLSpecialColumns(SQLHSTMT statement_handle, SQLSMALLINT identifier_type, SQLCHAR *catalog_name,
-                                    SQLSMALLINT name_length1, SQLCHAR *schema_name, SQLSMALLINT name_length2,
-                                    SQLCHAR *table_name, SQLSMALLINT name_length3, SQLSMALLINT scope,
-                                    SQLSMALLINT nullable) {
-	std::cout << "***** SQLSpecialColumns" << std::endl;
-	return SQL_ERROR;
-}
-
-SQLRETURN SQL_API SQLStatistics(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQLSMALLINT name_length1,
-                                SQLCHAR *schema_name, SQLSMALLINT name_length2, SQLCHAR *table_name,
-                                SQLSMALLINT name_length3, SQLUSMALLINT unique, SQLUSMALLINT reserved) {
-	std::cout << "***** SQLStatistics" << std::endl;
-	return SQL_ERROR;
-}
-
 SQLRETURN SQL_API SQLBrowseConnect(SQLHDBC connection_handle, SQLCHAR *in_connection_string, SQLSMALLINT string_length1,
                                    SQLCHAR *out_connection_string, SQLSMALLINT buffer_length,
                                    SQLSMALLINT *string_length2_ptr) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   tests/numeric.cpp
   tests/quotes.cpp
   tests/result_conversion.cpp
+  tests/test_stubs.cpp
   tests/col_attribute/col_attribute.cpp
   tests/col_attribute/char_query.cpp
   tests/col_attribute/int_query.cpp

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -13,8 +13,6 @@ using namespace odbc_test;
  * SQLGetInfo
  *
  * TODO: Test the following catalog functions:
- * - SQLSpecialColumns
- * - SQLStatistics
  * - SQLPrimaryKeys
  * - SQLForeignKeys
  * - SQLProcedureColumns
@@ -234,6 +232,13 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 	}
 }
 
+// Check that complex table type can be processed without errors
+static void TestSQLTablesSystemTable(HSTMT &hstmt) {
+	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
+	                  ConvertToSQLCHAR("%"), SQL_NTS,
+	                  ConvertToSQLCHAR("'TABLE','VIEW','SYSTEM TABLE','ALIAS','SYNONYM'"), SQL_NTS);
+}
+
 static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	EXECUTE_AND_CHECK("SQLColumns", SQLColumns, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("%"), SQL_NTS, nullptr, 0);
@@ -316,6 +321,7 @@ TEST_CASE("Test Catalog Functions (SQLGetTypeInfo, SQLTables, SQLColumns, SQLGet
 	TestSQLTables(hstmt, types_map);
 	TestSQLTablesLong(hstmt);
 	TestSQLTablesSchema(hstmt);
+	TestSQLTablesSystemTable(hstmt);
 
 	// Check for SQLColumns
 	TestSQLColumns(hstmt, types_map);

--- a/test/tests/test_stubs.cpp
+++ b/test/tests/test_stubs.cpp
@@ -1,0 +1,48 @@
+
+#include "odbc_test_common.h"
+
+using namespace odbc_test;
+
+TEST_CASE("Test SQLSpecialColumns and SQLStatistics stubs", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// Connect to the database using SQLConnect
+	CONNECT_TO_DATABASE(env, dbc);
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	{ // Check SQLSpecialColumns
+		EXECUTE_AND_CHECK("SQLSpecialColumns", SQLSpecialColumns, hstmt, 0, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
+
+		// Check columns
+		SQLSMALLINT col_count;
+		EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+		REQUIRE(col_count == 8);
+
+		// Check that the result set is empty
+		SQLRETURN ret = SQLFetch(hstmt);
+		REQUIRE(ret == SQL_NO_DATA);
+	}
+	{ // Check SQLStatistics
+		EXECUTE_AND_CHECK("SQLStatistics", SQLStatistics, hstmt, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
+		// Check columns
+		SQLSMALLINT col_count;
+		EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+		REQUIRE(col_count == 13);
+
+		// Check that the result set is empty
+		SQLRETURN ret = SQLFetch(hstmt);
+		REQUIRE(ret == SQL_NO_DATA);
+	}
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	// Disconnect from the database
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}


### PR DESCRIPTION
This change adds missing functionality that is necessary for MS Access to be able to perform schema introspection and tables import from DuckDB over ODBC.

Testing: tests added for all added bits.

Fixes: #39