### PR TITLE
Add test for extensions

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   tests/catalog_functions.cpp
   tests/connect.cpp
   tests/diagnostics.cpp
+  tests/extension.cpp
   tests/select.cpp
   tests/row_wise_fetching.cpp
   tests/set_attr.cpp

--- a/test/tests/extension.cpp
+++ b/test/tests/extension.cpp
@@ -1,0 +1,37 @@
+#include "odbc_test_common.h"
+
+using namespace odbc_test;
+
+// If this test fails the version of the vendored DuckDB doesn't have an extension build
+TEST_CASE("Test Extension", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// Connect to the database using SQLConnect
+	CONNECT_TO_DATABASE(env, dbc);
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	// Install and load the httpfs extension
+	EXECUTE_AND_CHECK("INSTALL httpfs", SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("INSTALL httpfs"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("LOAD httpfs", SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("LOAD httpfs"), SQL_NTS);
+
+	// Check if the extension is loaded
+	EXEC_SQL(hstmt, "SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs'");
+
+	// Should return true
+	EXECUTE_AND_CHECK("SQLFetch (SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs')", SQLFetch, hstmt);
+	DATA_CHECK(hstmt, 1, "true");
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}

--- a/test/tests/extension.cpp
+++ b/test/tests/extension.cpp
@@ -16,17 +16,16 @@ TEST_CASE("Test Extension", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Install and load the httpfs extension
-	EXECUTE_AND_CHECK("INSTALL httpfs", SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("INSTALL httpfs"), SQL_NTS);
+	EXECUTE_AND_CHECK("INSTALL httpfs", SQLExecDirect, hstmt, ConvertToSQLCHAR("INSTALL httpfs"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("LOAD httpfs", SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("LOAD httpfs"), SQL_NTS);
+	EXECUTE_AND_CHECK("LOAD httpfs", SQLExecDirect, hstmt, ConvertToSQLCHAR("LOAD httpfs"), SQL_NTS);
 
 	// Check if the extension is loaded
 	EXEC_SQL(hstmt, "SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs'");
 
 	// Should return true
-	EXECUTE_AND_CHECK("SQLFetch (SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs')", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs')", SQLFetch,
+	                  hstmt);
 	DATA_CHECK(hstmt, 1, "true");
 
 	// Free the statement handle


### PR DESCRIPTION
This PR adds a test for extensions. If the test fails, it means that there is a mismatch in DuckDB hashes between the ODBC driver and the extensions. 