### PR TITLE
Use push event to dispatch a rebuild after vendoring sources

### DIFF
--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: actions/checkout@v4
         with:
@@ -73,13 +74,3 @@ jobs:
       - if: steps.vendor.outputs.vendor != '' && github.event_name != 'pull_request'
         run: |
           git push -u origin HEAD
-
-      - name: Wait for push to complete
-        if: steps.vendor.outputs.vendor != '' && github.event_name != 'pull_request'
-        run: sleep 10  # Give GitHub a moment to process the push
-
-  rebuild:
-    needs: vendor
-    if: ${{ needs.vendor.outputs.did_vendor != '' }}
-    uses: ./.github/workflows/ODBC.yml
-    secrets: inherit


### PR DESCRIPTION
Currently `Vendor.yml` workflows pushes updated sources to the repo and then dispatches `ODBC.yml` workflow directly. The push on GitHub [is not synchronous](https://github.blog/engineering/architecture-optimization/how-we-improved-push-processing-on-github/), so there are no gaurantees that `ODBC.yml` will see the pushed changes even if we wait for 10 seconds before the dispatch.

This change instead relies on a `push` event to start the `ODBC.yml` workflow after the push. By default GitHub generates on-time token `GITHUB_TOKEN` that is used as a credentials during the workflow run. And this `GITHUB_TOKEN` is [restricted to not trigger the push event](https://github.com/orgs/community/discussions/25702).

Thus this change uses `secrets.PAT_TOKEN` token instead of the `GITHUB_TOKEN`. This `PAT_TOKEN` needs to be added as a secret to this repo. Minimal required permissions for it are `Contents: read-write`.

Testing: checked in another repo that this approach actually triggers the push event.