### PR TITLE
Use PRs when importing engine sources

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -33,6 +33,7 @@ jobs:
   format-check:
     name: Format Check
     runs-on: ubuntu-20.04
+    if: ${{ !(github.event_name == 'pull_request' && github.head_ref == 'vendoring') }}
 
     env:
       CC: gcc-10

--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -335,3 +335,38 @@ jobs:
         shell: bash
         run: ./test/run_pyodbc_tests.sh
 
+  odbc-merge-vendoring-pr:
+    name: Merge vendoring PR 
+    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == 'vendoring' }}
+    needs:
+      - odbc-linux-amd64
+      - odbc-linux-aarch64
+      - odbc-windows-amd64
+      - debug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Merge vendoring PR
+        id: merge_vendoring_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            # echo "Merging PR number: ${{ github.event.pull_request.number }} with message: ${{ github.event.pull_request.title }}"
+            gh pr merge vendoring \
+             --rebase \
+             --subject "${{ github.event.pull_request.title }}" \
+             --body ""
+
+      - name: Update vendoring branch
+        id: update_vendoring_branch
+        if: ${{ steps.merge_vendoring_pr.outcome == 'success' }}
+        run: |
+            # Delete vendoring branch and re-create it for future PRs
+            git push --delete origin vendoring
+            git checkout --track origin/main
+            git pull --ff-only
+            git branch vendoring
+            git push origin vendoring

--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -1,11 +1,5 @@
 name: Vendor
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'vendor.py'
-      - 'src/duckdb'
   workflow_call:
     inputs:
       duckdb-sha:
@@ -23,54 +17,139 @@ on:
 
 jobs:
   vendor:
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.commit.outputs.sha }}
-      did_vendor: ${{ steps.vendor.outputs.vendor }}
-
     name: "Update Vendored Sources"
+    if: ${{ github.repository == 'duckdb/duckdb-odbc' }}
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version: '3.12'
+
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - name: Checkout engine
+        uses: actions/checkout@v4
+        id: checkout_engine
         with:
           repository: duckdb/duckdb
           path: .git/duckdb
           fetch-depth: 0
 
-      - name: Get commit SHA
+      - name: Checkout engine rev 
+        id: checkout_engine_rev
         if: ${{ inputs.duckdb-sha != '' }}
+        working-directory: .git/duckdb
         run: |
-          cd .git/duckdb && git checkout ${{ inputs.duckdb-sha }}
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
+          git checkout ${{ inputs.duckdb-sha }}
 
       - name: Vendor sources
         id: vendor
         run: |
-          export REV=$(cd .git/duckdb && git rev-parse --short HEAD && cd ../..)
-          echo "Updating vendored DuckDB sources to $REV"
+          REV=$(cd .git/duckdb && git rev-parse --short HEAD && cd ../..)
+          echo "Updating vendored DuckDB sources to ${REV}"
           git config --global user.email "github_bot@duckdblabs.com"
           git config --global user.name "DuckDB Labs GitHub Bot"
+          # Vendoring branch must exist, it may or may not already have
+          # a pending PR on it, we are rebasing it anyway
+          git checkout vendoring
+          git rebase ${{ github.ref_name }}
+          # Call the vendoring script in the engine
           git rm -rf src/duckdb
           python vendor.py --duckdb .git/duckdb
           git add src/duckdb CMakeLists.txt
+          # Clean up
           rm -rf .git/duckdb
-          git commit -m "Update vendored DuckDB sources to $REV"
-          git push --dry-run
+          # Export vendor revision for use in later steps
+          echo "vendor_rev=${REV}" >> "${GITHUB_OUTPUT}"
+
+      - name: Commit and push the changes
+        id: commit_and_push
+        if: ${{ steps.vendor.outcome == 'success' }}
+        run: |
+          MSG="Update vendored DuckDB sources to ${{ steps.vendor.outputs.vendor_rev }}"
+          git commit -m "${MSG}"
           # Check if ahead of upstream branch
           # If yes, set a step output
+          git push -f --dry-run origin vendoring
           if [ $(git rev-list HEAD...origin/main --count) -gt 0 ]; then
+            git push -f origin vendoring
             # Avoid set-output, it's deprecated
-            echo "vendor=ok" >> "$GITHUB_OUTPUT"
+            echo "push_performed=true" >> "${GITHUB_OUTPUT}"
+            echo "commit_msg=${MSG}" >> "${GITHUB_OUTPUT}"
           fi
 
-      - if: steps.vendor.outputs.vendor != '' && github.event_name != 'pull_request'
+      - name: Check PR exists
+        id: check_pr_exists
+        if: ${{ steps.commit_and_push.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push -u origin HEAD
+          PR_NUM=$(gh pr list --head vendoring --json number --jq '.[].number')
+          if [ -z "${PR_NUM}" ]; then
+            echo "No PR exists for branch vendoring"
+            echo "pr_exists=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "PR found for branch vendoring, number: ${PR_NUM}"
+            echo "pr_exists=true" >> "${GITHUB_OUTPUT}"
+            echo "pr_num=${PR_NUM}" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Prepare PR message
+        id: prepare_pr_message
+        if: ${{ steps.check_pr_exists.outcome == 'success' }}
+        run: |
+            DATE="$(date +"%Y-%m-%d %H:%M:%S")"
+            CHANGE_LABEL="duckdb/duckdb#${{ steps.vendor.outputs.vendor_rev }}"
+            CHANGE_URL="https://github.com/duckdb/duckdb/commit/${{ steps.vendor.outputs.vendor_rev }}"
+            MSG=" - [${CHANGE_LABEL}](${CHANGE_URL}) imported at ${DATE}"
+            echo "PR message: ${MSG}"
+            echo "pr_msg=${MSG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create PR
+        id: create_pr
+        if: ${{ steps.prepare_pr_message.outcome == 'success' && steps.check_pr_exists.outputs.pr_exists == 'false' }}
+        env:
+          # We cannot use default workflow's GITHUB_TOKEN here, because
+          # it is restricted to not trigger 'pull_request' event that
+          # we need to dispatch the testing workflow.
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+            # Write multiline PR msg to a body.txt file 
+            echo "Changes:" > body.txt
+            echo "${{ steps.prepare_pr_message.outputs.pr_msg }}" >> body.txt
+            # Remove empty lines
+            sed -i '/^$/d' body.txt
+            gh pr create \
+             --head "vendoring" \
+             --base "main" \
+             --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
+             --body-file body.txt
+
+      - name: Update PR
+        id: update_pr
+        if: ${{ steps.prepare_pr_message.outcome == 'success' && steps.check_pr_exists.outputs.pr_exists == 'true' }}
+        env:
+          # We cannot use default workflow's GITHUB_TOKEN here, because
+          # it is restricted to not trigger 'pull_request' event that
+          # we need to dispatch the testing workflow.
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+            # Write existing PR body text to a file
+            gh pr view vendoring --json body --jq '.body' > body.txt
+            # Append change description
+            echo "${{ steps.prepare_pr_message.outputs.pr_msg }}" >> body.txt
+            # Remove empty lines
+            sed -i '/^$/d' body.txt
+            gh pr edit ${{ steps.check_pr_exists.outputs.pr_num }} \
+             --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
+             --body-file body.txt 
+            # Close and re-open the PR to trigger the tests
+            gh pr close ${{ steps.check_pr_exists.outputs.pr_num }}
+            gh pr reopen ${{ steps.check_pr_exists.outputs.pr_num }}


### PR DESCRIPTION
Currently `Vendor.yml` workflow imports DuckDB engine sources and commits the changes to the `main` branch straight away.

This PR changes this to import engine changes into a `vendoring` branch and create a PR on that branch. This PR triggers `ODBC.yml` tests runs. Additional job is added to `ODBC.yml` to merge the PRs on `vendoring` branch automatically after all tests are passed.

When the import happens and the PR on `vendoring` branch is still open (when previous import did not pass the tests), then the imported changes are added to the `vendoring` branch and the PR is closed and re-opened to trigger the `ODBC.yml` workflow run.

Non-default personal access token (`PAT_TOKEN` secret) must be used for creation or re-opening of the PR because the default token `GITHUB_TOKEN` is restricted to not trigger `pull_request` event. All other operations, besides the PR create/re-open, use the default token.

Merge is done by rebasing all `vendoring` commits onto `main` branch, thus the history of the imports should look the same (linear) as it looks now with direct pushes.

Testing: debugged this on a separate repo.