### PR TITLE
Print Diagnositcs from `ODBC_CHECK`

### DIFF
--- a/src/duckdb/src/include/duckdb/common/types/row/tuple_data_states.hpp
+++ b/src/duckdb/src/include/duckdb/common/types/row/tuple_data_states.hpp
@@ -10,7 +10,6 @@
 
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types.hpp"
-#include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/vector_cache.hpp"
 #include "duckdb/common/types/vector.hpp"
 

--- a/src/duckdb/src/include/duckdb/common/types/row/tuple_data_states.hpp
+++ b/src/duckdb/src/include/duckdb/common/types/row/tuple_data_states.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/vector_cache.hpp"
 #include "duckdb/common/types/vector.hpp"
 

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -3,7 +3,7 @@
 
 namespace odbc_test {
 
-void ODBC_CHECK(SQLRETURN ret, const std::string &msg) {
+void ODBC_CHECK(SQLRETURN ret, const std::string &msg, HSTMT hstmt) {
 	switch (ret) {
 	case SQL_SUCCESS:
 		REQUIRE(1);
@@ -24,6 +24,15 @@ void ODBC_CHECK(SQLRETURN ret, const std::string &msg) {
 		fprintf(stderr, "%s: Unexpected return value\n", msg.c_str());
 		break;
 	}
+	if (ret == SQL_ERROR && hstmt != nullptr) {
+		// Get the diagnostics
+		std::string state;
+		std::string message;
+
+		ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
+		std::cout << message << std::endl;
+	}
+
 	REQUIRE(SQL_SUCCEEDED(ret));
 }
 
@@ -51,7 +60,7 @@ void ACCESS_DIAGNOSTIC(std::string &state, std::string &message, SQLHANDLE handl
 	}
 
 	if (ret != SQL_NO_DATA) {
-		ODBC_CHECK(ret, "SQLGetDiagRec");
+		ODBC_CHECK(ret, "SQLGetDiagRec", handle);
 	}
 }
 
@@ -61,7 +70,7 @@ void DATA_CHECK(HSTMT &hstmt, SQLSMALLINT col_num, const std::string &expected_c
 
 	// SQLGetData returns data for a single column in the result set.
 	SQLRETURN ret = SQLGetData(hstmt, col_num, SQL_C_CHAR, content, sizeof(content), &content_len);
-	ODBC_CHECK(ret, "SQLGetData");
+	ODBC_CHECK(ret, "SQLGetData", hstmt);
 	if (content_len == SQL_NULL_DATA) {
 		REQUIRE(expected_content.empty());
 		return;
@@ -83,7 +92,7 @@ void METADATA_CHECK(HSTMT &hstmt, SQLUSMALLINT col_num, const std::string &expec
 	// column in a result set.
 	SQLRETURN ret = SQLDescribeCol(hstmt, col_num, col_name, sizeof(col_name), &col_name_len, &col_type, &col_size,
 	                               &col_decimal_digits, &col_nullable);
-	ODBC_CHECK(ret, "SQLDescribeCol");
+	ODBC_CHECK(ret, "SQLDescribeCol", hstmt);
 
 	if (!expected_col_name.empty()) {
 		REQUIRE(expected_col_name == ConvertToString(col_name));
@@ -130,14 +139,14 @@ void DRIVER_CONNECT_TO_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc, const std::strin
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	// SQLDriverConnect establishes connections to a driver and a data source.
 	// Supports data sources that require more connection information than the three arguments in SQLConnect.
-	EXECUTE_AND_CHECK("SQLDriverConnect", SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, str,
+	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, str,
 	                  sizeof(str), &strl, SQL_DRIVER_COMPLETE);
 }
 
@@ -147,25 +156,25 @@ void CONNECT_TO_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	// SQLConnect establishes connections to a driver and a data source.
-	EXECUTE_AND_CHECK("SQLConnect", SQLConnect, dbc, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
+	EXECUTE_AND_CHECK("SQLConnect", nullptr, SQLConnect, dbc, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
 }
 
 void DISCONNECT_FROM_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
-	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
 
-	EXECUTE_AND_CHECK("SQLDisconnect", SQLDisconnect, dbc);
+	EXECUTE_AND_CHECK("SQLDisconnect", nullptr, SQLDisconnect, dbc);
 
-	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
 }
 
 void EXEC_SQL(HSTMT hstmt, const std::string &query) {
-	EXECUTE_AND_CHECK("SQLExecDirect (" + query + ")", SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (" + query + ")", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()), SQL_NTS);
 }
 
 void InitializeDatabase(HSTMT &hstmt) {

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -55,7 +55,7 @@ void ACCESS_DIAGNOSTIC(std::string &state, std::string &message, SQLHANDLE handl
 		// calls to SQLGetDiagRec doesn't change the state of the statement, this is not a problem.
 		if (SQL_SUCCEEDED(ret)) {
 			state = ConvertToString(sqlstate);
-			message = ConvertToString(message_text);
+			message += ConvertToString(message_text);
 		}
 	}
 

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -146,8 +146,8 @@ void DRIVER_CONNECT_TO_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc, const std::strin
 
 	// SQLDriverConnect establishes connections to a driver and a data source.
 	// Supports data sources that require more connection information than the three arguments in SQLConnect.
-	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, str,
-	                  sizeof(str), &strl, SQL_DRIVER_COMPLETE);
+	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(dsn.c_str()),
+	                  SQL_NTS, str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
 }
 
 void CONNECT_TO_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
@@ -162,7 +162,8 @@ void CONNECT_TO_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
 	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	// SQLConnect establishes connections to a driver and a data source.
-	EXECUTE_AND_CHECK("SQLConnect", nullptr, SQLConnect, dbc, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, nullptr, 0, nullptr, 0);
+	EXECUTE_AND_CHECK("SQLConnect", nullptr, SQLConnect, dbc, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, nullptr, 0,
+	                  nullptr, 0);
 }
 
 void DISCONNECT_FROM_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
@@ -174,7 +175,8 @@ void DISCONNECT_FROM_DATABASE(SQLHANDLE &env, SQLHANDLE &dbc) {
 }
 
 void EXEC_SQL(HSTMT hstmt, const std::string &query) {
-	EXECUTE_AND_CHECK("SQLExecDirect (" + query + ")", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (" + query + ")", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()),
+	                  SQL_NTS);
 }
 
 void InitializeDatabase(HSTMT &hstmt) {

--- a/test/connect_helpers.cpp
+++ b/test/connect_helpers.cpp
@@ -25,7 +25,7 @@ void CheckDatabase(SQLHANDLE &dbc) {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Select * from customers
-	EXECUTE_AND_CHECK("SQLExecDirect (FROM string_values)",  hstmt, SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (FROM string_values)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("FROM string_values"), SQL_NTS);
 
 	// Fetch the first row and check the data

--- a/test/connect_helpers.cpp
+++ b/test/connect_helpers.cpp
@@ -6,32 +6,32 @@ using namespace odbc_test;
 
 void CheckConfig(SQLHANDLE &dbc, const std::string &setting, const std::string &expected_content) {
 	HSTMT hstmt = SQL_NULL_HSTMT;
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Check if the setting is successfully changed
-	EXECUTE_AND_CHECK("SQLExecDirect (select current_setting('" + setting + "'))", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (select current_setting('" + setting + "'))", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("select current_setting('" + setting + "')"), SQL_NTS);
 
 	// Fetch the first row
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, duckdb::StringUtil::Lower(expected_content));
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 void CheckDatabase(SQLHANDLE &dbc) {
 	HSTMT hstmt = SQL_NULL_HSTMT;
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Select * from customers
-	EXECUTE_AND_CHECK("SQLExecDirect (FROM string_values)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (FROM string_values)",  hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("FROM string_values"), SQL_NTS);
 
 	// Fetch the first row and check the data
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "hello world");
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }

--- a/test/include/odbc_test_common.h
+++ b/test/include/odbc_test_common.h
@@ -19,19 +19,20 @@ struct MetadataData {
 	SQLSMALLINT col_type;
 };
 
-void ODBC_CHECK(SQLRETURN ret, const std::string &func);
+void ODBC_CHECK(SQLRETURN ret, const std::string &func, HSTMT hstmt);
 
 /**
  * @brief
  * Two for one special! Runs the function passed as a param and then checks the return value using ODBC_CHECK.
  * @param msg The message to print if the return value is not SQL_SUCCESS
+ * @param hstmt A statement handle
  * @param func The function to run
  * @param args The arguments to pass to the function
  */
 template <typename MSG, typename FUNC, typename... ARGS>
-void EXECUTE_AND_CHECK(MSG msg, FUNC func, ARGS... args) {
+void EXECUTE_AND_CHECK(MSG msg, HSTMT hstmt, FUNC func, ARGS... args) {
 	SQLRETURN ret = func(args...);
-	ODBC_CHECK(ret, msg);
+	ODBC_CHECK(ret, msg, hstmt);
 }
 
 /**

--- a/test/tests/alter.cpp
+++ b/test/tests/alter.cpp
@@ -11,42 +11,42 @@ TEST_CASE("Test ALTER TABLE statement", "[odbc]") {
 	// Connect to the database
 	CONNECT_TO_DATABASE(env, dbc);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Create a table to test with
-	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("CREATE TABLE testtbl(t varchar(40))"), SQL_NTS);
 
 	// A simple query against the table, fetch column info
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM testtbl"),
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM testtbl"),
 	                  SQL_NTS);
 
 	// Get number of columns
 	SQLSMALLINT num_cols;
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &num_cols);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &num_cols);
 	REQUIRE(num_cols == 1);
 
 	// Retrieve metadata from the column
 	METADATA_CHECK(hstmt, num_cols, "t", sizeof('t'), SQL_VARCHAR, types_map[SQL_VARCHAR], 0, SQL_NULLABLE_UNKNOWN);
 
 	// Alter the table
-	EXECUTE_AND_CHECK("SQLExecDirect (ALTER TABLE)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (ALTER TABLE)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("ALTER TABLE testtbl ALTER t SET DATA TYPE int"), SQL_NTS);
 
 	// Rerun the query to check if the metadata was updated
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM testtbl"),
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM testtbl"),
 	                  SQL_NTS);
 
 	// Get number of columns
 	SQLSMALLINT num_cols_updated;
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &num_cols_updated);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &num_cols_updated);
 	REQUIRE(num_cols_updated == 1);
 
 	// Retrieve metadata from the column
 	METADATA_CHECK(hstmt, num_cols_updated, "t", sizeof('t'), SQL_INTEGER, types_map[SQL_INTEGER], 0,
 	               SQL_NULLABLE_UNKNOWN);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/basic_usage.cpp
+++ b/test/tests/basic_usage.cpp
@@ -13,26 +13,26 @@ TEST_CASE("Basic ODBC usage", "[odbc]") {
 	REQUIRE(ret == SQL_SUCCESS);
 
 	ret = SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION, ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
-	ODBC_CHECK(ret, "SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)");
+	ODBC_CHECK(ret, "SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr);
 
 	ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
-	ODBC_CHECK(ret, "SQLAllocHandle (DBC)");
+	ODBC_CHECK(ret, "SQLAllocHandle (DBC)", nullptr);
 
 	ret = SQLConnect(dbc, ConvertToSQLCHAR(dsn), SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS);
-	ODBC_CHECK(ret, "SQLConnect");
+	ODBC_CHECK(ret, "SQLConnect", nullptr);
 
 	ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &stmt);
-	ODBC_CHECK(ret, "SQLAllocHandle (STMT)");
+	ODBC_CHECK(ret, "SQLAllocHandle (STMT)", stmt);
 
 	ret = SQLFreeHandle(SQL_HANDLE_STMT, stmt);
-	ODBC_CHECK(ret, "SQLFreeHandle (STMT)");
+	ODBC_CHECK(ret, "SQLFreeHandle (STMT)", stmt);
 
 	ret = SQLDisconnect(dbc);
-	ODBC_CHECK(ret, "SQLDisconnect");
+	ODBC_CHECK(ret, "SQLDisconnect", stmt);
 
 	ret = SQLFreeHandle(SQL_HANDLE_DBC, dbc);
-	ODBC_CHECK(ret, "SQLFreeHandle (DBC)");
+	ODBC_CHECK(ret, "SQLFreeHandle (DBC)", stmt);
 
 	ret = SQLFreeHandle(SQL_HANDLE_ENV, env);
-	ODBC_CHECK(ret, "SQLFreeHandle (ENV)");
+	ODBC_CHECK(ret, "SQLFreeHandle (ENV)", stmt);
 }

--- a/test/tests/bind_col.cpp
+++ b/test/tests/bind_col.cpp
@@ -18,18 +18,18 @@ TEST_CASE("Test SQLBindCol (binding columns to application buffers)", "[odbc]") 
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Bind the first column (long_value) to a long
-	EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", SQLBindCol, hstmt, 1, SQL_C_LONG, &long_value, sizeof(SQLINTEGER),
+	EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 1, SQL_C_LONG, &long_value, sizeof(SQLINTEGER),
 	                  &ind_long_value);
 
 	// Bind the second column (char_value) to a string
-	EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value, sizeof(char_value),
+	EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value, sizeof(char_value),
 	                  &ind_char_value);
 
 	// Execute the query
-	EXECUTE_AND_CHECK("SQLExecDirect (HSTMT)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (HSTMT)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT id, 'foo' || id FROM generate_series(1, 10) id(id)"), SQL_NTS);
 
 	SQLINTEGER row_num = 0;
@@ -51,22 +51,22 @@ TEST_CASE("Test SQLBindCol (binding columns to application buffers)", "[odbc]") 
 
 		// unbind the text field on row 3
 		if (row_num == 3) {
-			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", SQLBindCol, hstmt, 2, SQL_C_CHAR, nullptr, 0, nullptr);
+			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, nullptr, 0, nullptr);
 		}
 		// rebind the text field on row 5 and 9
 		if (row_num == 5 || row_num == 9) {
-			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value, sizeof(char_value),
+			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value, sizeof(char_value),
 			                  &ind_char_value);
 		}
 		// unbind both fields on row 7 using SQLFreeStmt(SQL_UNBIND)
 		if (row_num == 7) {
-			EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_UNBIND);
+			EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_UNBIND);
 		}
 	}
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/bind_col.cpp
+++ b/test/tests/bind_col.cpp
@@ -55,8 +55,8 @@ TEST_CASE("Test SQLBindCol (binding columns to application buffers)", "[odbc]") 
 		}
 		// rebind the text field on row 5 and 9
 		if (row_num == 5 || row_num == 9) {
-			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value, sizeof(char_value),
-			                  &ind_char_value);
+			EXECUTE_AND_CHECK("SQLBindCol (HSTMT)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, &char_value,
+			                  sizeof(char_value), &ind_char_value);
 		}
 		// unbind both fields on row 7 using SQLFreeStmt(SQL_UNBIND)
 		if (row_num == 7) {

--- a/test/tests/bools_as_char.cpp
+++ b/test/tests/bools_as_char.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	InitializeDatabase(hstmt);
 
@@ -25,27 +25,27 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	 */
 
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id, t, b FROM bool_table WHERE t = ?"),
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id, t, b FROM bool_table WHERE t = ?"),
 	                  SQL_NTS);
 
 	// Bind param
 	const char *param = "yes";
 	SQLLEN param_len = SQL_NTS;
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
 	                  (SQLPOINTER)param, strlen(param), &param_len);
 
 	// Execute
-	EXECUTE_AND_CHECK("SQLExecute", SQLExecute, hstmt);
+	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 
 	// Fetch result
 	METADATA_CHECK(hstmt, 3, "b", sizeof('b'), SQL_CHAR, types_map[SQL_CHAR], 0, SQL_NULLABLE_UNKNOWN);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "2");
 	DATA_CHECK(hstmt, 2, "yes");
 	DATA_CHECK(hstmt, 3, "true");
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 
 	/**
 	 * A simple query with one boolean param (passed as varchar)
@@ -54,11 +54,11 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	// Bind param
 	param = "true";
 	param_len = SQL_NTS;
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
 	                  (SQLPOINTER)param, strlen(param), &param_len);
 
 	// Execute
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT id, t, b FROM bool_table WHERE b = ?"), SQL_NTS);
 
 	// Fetch result
@@ -67,15 +67,15 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	std::vector<std::string> expected_data[3] = {{"1", "yeah", "true"}, {"2", "yes", "true"}, {"3", "true", "true"}};
 
 	for (int i = 0; i < 3; i++) {
-		EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 		DATA_CHECK(hstmt, 1, expected_data[i][0]);
 		DATA_CHECK(hstmt, 2, expected_data[i][1]);
 		DATA_CHECK(hstmt, 3, expected_data[i][2]);
 	}
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/bools_as_char.cpp
+++ b/test/tests/bools_as_char.cpp
@@ -25,14 +25,14 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	 */
 
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id, t, b FROM bool_table WHERE t = ?"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+	                  ConvertToSQLCHAR("SELECT id, t, b FROM bool_table WHERE t = ?"), SQL_NTS);
 
 	// Bind param
 	const char *param = "yes";
 	SQLLEN param_len = SQL_NTS;
-	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
-	                  (SQLPOINTER)param, strlen(param), &param_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	                  5, 0, (SQLPOINTER)param, strlen(param), &param_len);
 
 	// Execute
 	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
@@ -54,8 +54,8 @@ TEST_CASE("Test bools to char conversion", "[odbc]") {
 	// Bind param
 	param = "true";
 	param_len = SQL_NTS;
-	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR, 5, 0,
-	                  (SQLPOINTER)param, strlen(param), &param_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	                  5, 0, (SQLPOINTER)param, strlen(param), &param_len);
 
 	// Execute
 	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -65,7 +65,8 @@ void TestGetTypeInfo(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	SQLINTEGER data_type;
 	SQLLEN row_count = 0;
 	SQLLEN len_or_ind_ptr;
-	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 2, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 2, SQL_INTEGER, &data_type, sizeof(data_type),
+	                  &len_or_ind_ptr);
 	EXECUTE_AND_CHECK("SQLGetTypeInfo(SQL_ALL_TYPES)", hstmt, SQLGetTypeInfo, hstmt, SQL_ALL_TYPES);
 
 	SQLINTEGER data_types[] = {
@@ -179,8 +180,8 @@ static void TestSQLTablesLong(HSTMT &hstmt) {
 	// FIXME: this test is broken
 	return;
 
-	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("main"), SQL_NTS,
-	                  ConvertToSQLCHAR("test_table_%"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("main"),
+	                  SQL_NTS, ConvertToSQLCHAR("test_table_%"), SQL_NTS,
 	                  ConvertToSQLCHAR("1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,'TABLE'"),
 	                  SQL_NTS);
 
@@ -208,8 +209,8 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 	DATA_CHECK(hstmt, 4, "TABLE");
 
 	// No schema name should give all tables, including main schema
-	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("%"),
-	                  SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR(""), SQL_NTS,
+	                  ConvertToSQLCHAR("%"), SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
 
 	std::vector<std::array<std::string, 4>> expected_data = {
 	    {"test_table_2", "ducks"},  {"bool_table", "main"},    {"bytea_table", "main"}, {"decimal_table", "main"},
@@ -437,7 +438,8 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 	SQLINTEGER sql_data_type;
 	SQLINTEGER data_type;
 	SQLLEN len_or_ind_ptr;
-	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 5, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 5, SQL_INTEGER, &data_type, sizeof(data_type),
+	                  &len_or_ind_ptr);
 	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 14, SQL_INTEGER, &sql_data_type, sizeof(sql_data_type),
 	                  &len_or_ind_ptr);
 
@@ -460,8 +462,8 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 
 	// Use SQLDescribeCol to assert that the data type is the same for each column
 	// Select * from the table
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT *)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT *)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT * FROM test_table"), SQL_NTS);
 
 	// Fetch the results
 	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -25,12 +25,12 @@ void TestGetTypeInfo(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	SQLSMALLINT col_count;
 
 	// Check for SQLGetTypeInfo
-	EXECUTE_AND_CHECK("SQLGetTypeInfo", SQLGetTypeInfo, hstmt, SQL_VARCHAR);
+	EXECUTE_AND_CHECK("SQLGetTypeInfo", hstmt, SQLGetTypeInfo, hstmt, SQL_VARCHAR);
 
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 	REQUIRE(col_count == 19);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 
 	std::string max_col_size = std::to_string((std::numeric_limits<SQLINTEGER>::max)());
 
@@ -65,8 +65,8 @@ void TestGetTypeInfo(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	SQLINTEGER data_type;
 	SQLLEN row_count = 0;
 	SQLLEN len_or_ind_ptr;
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt, 2, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
-	EXECUTE_AND_CHECK("SQLGetTypeInfo(SQL_ALL_TYPES)", SQLGetTypeInfo, hstmt, SQL_ALL_TYPES);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 2, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
+	EXECUTE_AND_CHECK("SQLGetTypeInfo(SQL_ALL_TYPES)", hstmt, SQLGetTypeInfo, hstmt, SQL_ALL_TYPES);
 
 	SQLINTEGER data_types[] = {
 	    SQL_CHAR,
@@ -106,18 +106,18 @@ void TestGetTypeInfo(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	}
 
 	// unbind column
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt, 2, SQL_INTEGER, nullptr, 0, nullptr);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 2, SQL_INTEGER, nullptr, 0, nullptr);
 }
 
 static void TestSQLTables(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 	SQLRETURN ret;
 
-	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("%"), SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
 
 	SQLSMALLINT col_count;
 
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 	REQUIRE(col_count == 5);
 
 	std::vector<MetadataData> expected_metadata = {{"TABLE_CAT", SQL_VARCHAR},
@@ -144,7 +144,7 @@ static void TestSQLTables(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_ma
 			REQUIRE(state == "07006");
 			REQUIRE(duckdb::StringUtil::Contains(message, "Invalid Input Error"));
 		} else {
-			ODBC_CHECK(ret, "SQLFetch");
+			ODBC_CHECK(ret, "SQLFetch", hstmt);
 		}
 		fetch_count++;
 
@@ -179,7 +179,7 @@ static void TestSQLTablesLong(HSTMT &hstmt) {
 	// FIXME: this test is broken
 	return;
 
-	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("main"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("test_table_%"), SQL_NTS,
 	                  ConvertToSQLCHAR("1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,6,7,8,9,0,1,2,3,4,5,'TABLE'"),
 	                  SQL_NTS);
@@ -193,12 +193,12 @@ static void TestSQLTablesLong(HSTMT &hstmt) {
 static void TestSQLTablesSchema(HSTMT &hstmt) {
 	SQLRETURN ret;
 
-	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("ducks"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("ducks"), SQL_NTS,
 	                  ConvertToSQLCHAR("%"), SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
 
 	SQLSMALLINT col_count;
 
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 	REQUIRE(col_count == 5);
 
 	ret = SQLFetch(hstmt);
@@ -208,7 +208,7 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 	DATA_CHECK(hstmt, 4, "TABLE");
 
 	// No schema name should give all tables, including main schema
-	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("%"),
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("%"),
 	                  SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
 
 	std::vector<std::array<std::string, 4>> expected_data = {
@@ -224,7 +224,7 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 			REQUIRE(duckdb::StringUtil::Contains(message, "Invalid Input Error"));
 			ret = SQL_SUCCESS;
 		} else {
-			ODBC_CHECK(ret, "SQLFetch");
+			ODBC_CHECK(ret, "SQLFetch", hstmt);
 		}
 
 		auto &entry = expected_data[i];
@@ -237,18 +237,18 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 
 // Check that complex table type can be processed without errors
 static void TestSQLTablesSystemTable(HSTMT &hstmt) {
-	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLTables", hstmt, SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("%"), SQL_NTS,
 	                  ConvertToSQLCHAR("'TABLE','VIEW','SYSTEM TABLE','ALIAS','SYNONYM'"), SQL_NTS);
 }
 
 static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
-	EXECUTE_AND_CHECK("SQLColumns", SQLColumns, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLColumns", hstmt, SQLColumns, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("%"), SQL_NTS, nullptr, 0);
 
 	SQLSMALLINT col_count;
 
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 	REQUIRE(col_count == 18);
 
 	// Create a map of column types and a vector of expected metadata
@@ -293,7 +293,7 @@ static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_m
 			REQUIRE(duckdb::StringUtil::Contains(message, "Invalid Input Error"));
 			ret = SQL_SUCCESS;
 		} else {
-			ODBC_CHECK(ret, "SQLFetch");
+			ODBC_CHECK(ret, "SQLFetch", hstmt);
 		}
 
 		auto &entry = expected_data[i];
@@ -317,13 +317,13 @@ TEST_CASE("Test Catalog Functions (SQLGetTypeInfo, SQLTables, SQLColumns, SQLGet
 	// Connect to the database using SQLConnect
 	CONNECT_TO_DATABASE(env, dbc);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Initializes the database with dummy data
 	InitializeDatabase(hstmt);
 
 	// Drop the test table if it exists
-	EXECUTE_AND_CHECK("SQLExecDirect (DROP TABLE)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (DROP TABLE)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("DROP TABLE IF EXISTS test_table"), SQL_NTS);
 
 	// Check for SQLGetTypeInfo
@@ -341,20 +341,20 @@ TEST_CASE("Test Catalog Functions (SQLGetTypeInfo, SQLTables, SQLColumns, SQLGet
 	// Test SQLGetInfo
 	char database_name[128];
 	SQLSMALLINT len;
-	EXECUTE_AND_CHECK("SQLGetInfo (SQL_TABLE_TERM)", SQLGetInfo, hstmt, SQL_TABLE_TERM, database_name,
+	EXECUTE_AND_CHECK("SQLGetInfo (SQL_TABLE_TERM)", hstmt, SQLGetInfo, hstmt, SQL_TABLE_TERM, database_name,
 	                  sizeof(database_name), &len);
 	REQUIRE(STR_EQUAL(database_name, "table"));
 
 	SQLSMALLINT oac_val;
 	SQLSMALLINT oac_val_len;
-	EXECUTE_AND_CHECK("SQLGetInfo (SQL_ODBC_API_CONFORMANCE)", SQLGetInfo, hstmt, SQL_ODBC_API_CONFORMANCE,
+	EXECUTE_AND_CHECK("SQLGetInfo (SQL_ODBC_API_CONFORMANCE)", hstmt, SQLGetInfo, hstmt, SQL_ODBC_API_CONFORMANCE,
 	                  static_cast<SQLPOINTER>(&oac_val), 2, &oac_val_len);
 	REQUIRE(SQL_OAC_LEVEL1 == oac_val);
 	REQUIRE(2 == oac_val_len); // required by MS Access
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);
@@ -372,7 +372,7 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	std::vector<int> SQL_types = {
 	    SQL_VARCHAR, SQL_SMALLINT, SQL_INTEGER,   SQL_FLOAT,     SQL_DOUBLE,    SQL_BIT,
@@ -421,24 +421,24 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 	}
 
 	// Create a table with different SQL types
-	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
 
 	// Insert data into the table
-	EXECUTE_AND_CHECK("SQLExecDirect (INSERT INTO)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (INSERT INTO)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("INSERT INTO test_table VALUES ('a', 1, 2, 3.14, 3.14159, true, 1, 10000000000, "
 	                                   "'blob', '2021-01-01', '12:00:00')"),
 	                  SQL_NTS);
 
 	// Call SQLColumns to get the columns of the test_table
-	EXECUTE_AND_CHECK("SQLColumns", SQLColumns, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLColumns", hstmt, SQLColumns, hstmt, nullptr, 0, ConvertToSQLCHAR("main"), SQL_NTS,
 	                  ConvertToSQLCHAR("test_table"), SQL_NTS, nullptr, 0);
 
 	// Retrieve SQL_DATA_TYPE and DATA_TYPE for each column
 	SQLINTEGER sql_data_type;
 	SQLINTEGER data_type;
 	SQLLEN len_or_ind_ptr;
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt, 5, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt, 14, SQL_INTEGER, &sql_data_type, sizeof(sql_data_type),
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 5, SQL_INTEGER, &data_type, sizeof(data_type), &len_or_ind_ptr);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 14, SQL_INTEGER, &sql_data_type, sizeof(sql_data_type),
 	                  &len_or_ind_ptr);
 
 	// Fetch the results
@@ -451,7 +451,7 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 			REQUIRE(duckdb::StringUtil::Contains(message, "Invalid Input Error"));
 			ret = SQL_SUCCESS;
 		} else {
-			ODBC_CHECK(ret, "SQLFetch");
+			ODBC_CHECK(ret, "SQLFetch", hstmt);
 		}
 
 		REQUIRE(data_type == SQL_types[i]);
@@ -460,11 +460,11 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 
 	// Use SQLDescribeCol to assert that the data type is the same for each column
 	// Select * from the table
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT *)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT *)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
 	                  SQL_NTS);
 
 	// Fetch the results
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 
 	// Check the data types of the columns using METADATA_CHECK which calls SQLDescribeCol
 	for (int i = 0; i < SQL_types.size(); i++) {
@@ -473,8 +473,8 @@ TEST_CASE("Test SQLColumns DATA_TYPE and SQL_DATA_TYPE and compare to SQLDescrib
 	}
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/col_attribute/char_query.cpp
+++ b/test/tests/col_attribute/char_query.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Test SQLColAttribute for a query that returns a char", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// run a simple query with chars to get a result set
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 'a' AS a, 'b' AS b"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 'a' AS a, 'b' AS b"), SQL_NTS);
 	std::map<SQLLEN, ExpectedResult> expected_chars;
 	expected_chars[SQL_DESC_CASE_SENSITIVE] = ExpectedResult(SQL_TRUE);
 	expected_chars[SQL_DESC_CATALOG_NAME] = ExpectedResult("system");
@@ -41,8 +41,8 @@ TEST_CASE("Test SQLColAttribute for a query that returns a char", "[odbc]") {
 	TestAllFields(hstmt, expected_chars);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/col_attribute/char_query.cpp
+++ b/test/tests/col_attribute/char_query.cpp
@@ -15,7 +15,8 @@ TEST_CASE("Test SQLColAttribute for a query that returns a char", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// run a simple query with chars to get a result set
-	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 'a' AS a, 'b' AS b"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 'a' AS a, 'b' AS b"),
+	                  SQL_NTS);
 	std::map<SQLLEN, ExpectedResult> expected_chars;
 	expected_chars[SQL_DESC_CASE_SENSITIVE] = ExpectedResult(SQL_TRUE);
 	expected_chars[SQL_DESC_CATALOG_NAME] = ExpectedResult("system");

--- a/test/tests/col_attribute/col_attribute.cpp
+++ b/test/tests/col_attribute/col_attribute.cpp
@@ -13,10 +13,10 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Get column attributes of a simple query
-	EXECUTE_AND_CHECK("SQLExectDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExectDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT "
 	                                   "'1'::int AS intcol, "
 	                                   "'foobar'::text AS textcol, "
@@ -29,7 +29,7 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 
 	// Get the number of columns
 	SQLSMALLINT num_cols;
-	EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &num_cols);
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &num_cols);
 	REQUIRE(num_cols == 7);
 
 	// Loop through the columns
@@ -37,15 +37,15 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 		char buffer[64];
 
 		// Get the column label
-		EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, hstmt, i, SQL_DESC_LABEL, buffer, sizeof(buffer), nullptr,
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_LABEL, buffer, sizeof(buffer), nullptr,
 		                  nullptr);
 
 		// Get the column name and base column name
 		char col_name[64];
 		char base_col_name[64];
-		EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, hstmt, i, SQL_DESC_NAME, col_name, sizeof(col_name),
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_NAME, col_name, sizeof(col_name),
 		                  nullptr, nullptr);
-		EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, hstmt, i, SQL_DESC_BASE_COLUMN_NAME, base_col_name,
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_BASE_COLUMN_NAME, base_col_name,
 		                  sizeof(base_col_name), nullptr, nullptr);
 		REQUIRE(STR_EQUAL(col_name, base_col_name));
 		switch (i) {
@@ -90,7 +90,7 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 		CheckInteger(hstmt, 0, SQL_DESC_OCTET_LENGTH);
 
 		// Get the column type name
-		EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, hstmt, i, SQL_DESC_TYPE_NAME, buffer, sizeof(buffer),
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_TYPE_NAME, buffer, sizeof(buffer),
 		                  nullptr, nullptr);
 		switch (i) {
 		case 1:
@@ -115,23 +115,23 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 
 	// Create table and retrieve base table name using SQLColAttribute, should fail because the statement is not a
 	// SELECT
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("CREATE TABLE test (a INTEGER, b INTEGER)"), SQL_NTS);
 	ExpectError(hstmt, SQL_DESC_BASE_TABLE_NAME);
 
 	// Prepare a statement and call SQLColAttribute, succeeds but is undefined
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("create table colattrfoo(col1 int, col2 varchar(20))"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLPrepare", SQLPrepare, hstmt, ConvertToSQLCHAR("select * From colattrfoo"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("select * From colattrfoo"), SQL_NTS);
 
 	SQLLEN fixed_prec_scale;
-	EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, hstmt, 1, SQL_DESC_FIXED_PREC_SCALE, nullptr, 0, nullptr,
+	EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_FIXED_PREC_SCALE, nullptr, 0, nullptr,
 	                  &fixed_prec_scale);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/col_attribute/col_attribute.cpp
+++ b/test/tests/col_attribute/col_attribute.cpp
@@ -37,14 +37,14 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 		char buffer[64];
 
 		// Get the column label
-		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_LABEL, buffer, sizeof(buffer), nullptr,
-		                  nullptr);
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_LABEL, buffer, sizeof(buffer),
+		                  nullptr, nullptr);
 
 		// Get the column name and base column name
 		char col_name[64];
 		char base_col_name[64];
-		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_NAME, col_name, sizeof(col_name),
-		                  nullptr, nullptr);
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_NAME, col_name,
+		                  sizeof(col_name), nullptr, nullptr);
 		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_BASE_COLUMN_NAME, base_col_name,
 		                  sizeof(base_col_name), nullptr, nullptr);
 		REQUIRE(STR_EQUAL(col_name, base_col_name));
@@ -90,8 +90,8 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 		CheckInteger(hstmt, 0, SQL_DESC_OCTET_LENGTH);
 
 		// Get the column type name
-		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_TYPE_NAME, buffer, sizeof(buffer),
-		                  nullptr, nullptr);
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, i, SQL_DESC_TYPE_NAME, buffer,
+		                  sizeof(buffer), nullptr, nullptr);
 		switch (i) {
 		case 1:
 			REQUIRE(STR_EQUAL(buffer, "INT32"));
@@ -126,8 +126,8 @@ TEST_CASE("Test General SQLColAttribute (descriptor information for a column)", 
 	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("select * From colattrfoo"), SQL_NTS);
 
 	SQLLEN fixed_prec_scale;
-	EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_FIXED_PREC_SCALE, nullptr, 0, nullptr,
-	                  &fixed_prec_scale);
+	EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_FIXED_PREC_SCALE, nullptr, 0,
+	                  nullptr, &fixed_prec_scale);
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);

--- a/test/tests/col_attribute/int_query.cpp
+++ b/test/tests/col_attribute/int_query.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Test SQLColAttribute for a query that returns an int", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// run a simple query  with ints to get a result set
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 1 AS a, 2 AS b"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT 1 AS a, 2 AS b"), SQL_NTS);
 	std::map<SQLLEN, ExpectedResult> expected_int;
 	expected_int[SQL_DESC_CASE_SENSITIVE] = ExpectedResult(SQL_FALSE);
 	expected_int[SQL_DESC_CATALOG_NAME] = ExpectedResult("system");
@@ -41,8 +41,8 @@ TEST_CASE("Test SQLColAttribute for a query that returns an int", "[odbc]") {
 	TestAllFields(hstmt, expected_int);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/col_attribute/interval_query.cpp
+++ b/test/tests/col_attribute/interval_query.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Test SQLColAttribute for a query that returns an interval", "[odbc]")
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// run a simple query  with ints to get a result set
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT INTERVAL 1 HOUR AS a, INTERVAL 2 HOUR AS b"), SQL_NTS);
 	std::map<SQLLEN, ExpectedResult> expected_interval;
 	expected_interval[SQL_DESC_CASE_SENSITIVE] = ExpectedResult(SQL_FALSE);
@@ -42,8 +42,8 @@ TEST_CASE("Test SQLColAttribute for a query that returns an interval", "[odbc]")
 	TestAllFields(hstmt, expected_interval);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/col_attribute/utils.cpp
+++ b/test/tests/col_attribute/utils.cpp
@@ -4,14 +4,15 @@ using namespace odbc_col_attribute_test;
 
 void odbc_col_attribute_test::CheckString(SQLHANDLE handle, const std::string &expected, SQLSMALLINT field_identifier) {
 	SQLCHAR buffer[64];
-	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, buffer, sizeof(buffer), nullptr,
-	                  nullptr);
+	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, buffer, sizeof(buffer),
+	                  nullptr, nullptr);
 	REQUIRE(ConvertToString(buffer) == expected);
 }
 
 void odbc_col_attribute_test::CheckInteger(SQLHANDLE handle, SQLLEN expected, SQLSMALLINT field_identifier) {
 	SQLLEN number;
-	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, nullptr, 0, nullptr, &number);
+	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, nullptr, 0, nullptr,
+	                  &number);
 	REQUIRE(number == expected);
 }
 

--- a/test/tests/col_attribute/utils.cpp
+++ b/test/tests/col_attribute/utils.cpp
@@ -4,14 +4,14 @@ using namespace odbc_col_attribute_test;
 
 void odbc_col_attribute_test::CheckString(SQLHANDLE handle, const std::string &expected, SQLSMALLINT field_identifier) {
 	SQLCHAR buffer[64];
-	EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, handle, 1, field_identifier, buffer, sizeof(buffer), nullptr,
+	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, buffer, sizeof(buffer), nullptr,
 	                  nullptr);
 	REQUIRE(ConvertToString(buffer) == expected);
 }
 
 void odbc_col_attribute_test::CheckInteger(SQLHANDLE handle, SQLLEN expected, SQLSMALLINT field_identifier) {
 	SQLLEN number;
-	EXECUTE_AND_CHECK("SQLColAttribute", SQLColAttribute, handle, 1, field_identifier, nullptr, 0, nullptr, &number);
+	EXECUTE_AND_CHECK("SQLColAttribute", nullptr, SQLColAttribute, handle, 1, field_identifier, nullptr, 0, nullptr, &number);
 	REQUIRE(number == expected);
 }
 

--- a/test/tests/col_attribute/uuid_query.cpp
+++ b/test/tests/col_attribute/uuid_query.cpp
@@ -12,10 +12,10 @@ TEST_CASE("Test SQLColAttribute for a query that returns a uuid", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// run a simple query with chars to get a result set
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT gen_random_uuid() AS a, uuid() AS b"), SQL_NTS);
 	std::map<SQLLEN, ExpectedResult> expected_chars;
 	expected_chars[SQL_DESC_CASE_SENSITIVE] = ExpectedResult(SQL_TRUE);
@@ -42,8 +42,8 @@ TEST_CASE("Test SQLColAttribute for a query that returns a uuid", "[odbc]") {
 	TestAllFields(hstmt, expected_chars);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);

--- a/test/tests/connect.cpp
+++ b/test/tests/connect.cpp
@@ -16,12 +16,12 @@ void ConnectWithoutDSN(SQLHANDLE &env, SQLHANDLE &dbc) {
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
-	EXECUTE_AND_CHECK("SQLDriverConnect", SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS,
 	                  str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
 }
 
@@ -37,12 +37,12 @@ void ConnectWithPowerQuerySDK(SQLHANDLE &env, SQLHANDLE &dbc) {
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
-	EXECUTE_AND_CHECK("SQLDriverConnect", SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str), SQL_NTS,
+	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str), SQL_NTS,
 	                  out_str_vec.data(), out_str_vec.size(), &out_str_len, SQL_DRIVER_COMPLETE);
 	REQUIRE(out_str_len > 0);
 	auto out_str = std::string(reinterpret_cast<char *>(out_str_vec.data()), static_cast<std::size_t>(out_str_len));
@@ -62,10 +62,10 @@ void ConnectWithIncorrectParam(std::string param) {
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR(dsn.c_str()), SQL_NTS, str, sizeof(str), &strl,
 	                       SQL_DRIVER_COMPLETE);
@@ -174,18 +174,18 @@ TEST_CASE("Test user_agent - in-memory database", "[odbc][useragent]") {
 	DRIVER_CONNECT_TO_DATABASE(env, dbc, "");
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Execute a simple query
 	EXECUTE_AND_CHECK(
-	    "SQLExecDirect (get user_agent)", SQLExecDirect, hstmt,
+	    "SQLExecDirect (get user_agent)", hstmt, SQLExecDirect, hstmt,
 	    ConvertToSQLCHAR("SELECT regexp_matches(user_agent, '^duckdb/.*(.*) odbc') FROM pragma_user_agent()"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "true");
 
 	// Free the env handle
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -200,18 +200,18 @@ TEST_CASE("Test user_agent - named database", "[odbc][useragent]") {
 	DRIVER_CONNECT_TO_DATABASE(env, dbc, "Database=test_odbc_named.db");
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Execute a simple query
 	EXECUTE_AND_CHECK(
-	    "SQLExecDirect (get user_agent)", SQLExecDirect, hstmt,
+	    "SQLExecDirect (get user_agent)", hstmt, SQLExecDirect, hstmt,
 	    ConvertToSQLCHAR("SELECT regexp_matches(user_agent, '^duckdb/.*(.*) odbc') FROM pragma_user_agent()"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "true");
 
 	// Free the env handle
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -227,20 +227,20 @@ TEST_CASE("Test user_agent - named database, custom useragent", "[odbc][useragen
 	DRIVER_CONNECT_TO_DATABASE(env, dbc, "Database=test_odbc_named_ua.db;custom_user_agent=CUSTOM_STRING");
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Execute a simple query
 	EXECUTE_AND_CHECK(
-	    "SQLExecDirect (get user_agent)", SQLExecDirect, hstmt,
+	    "SQLExecDirect (get user_agent)", hstmt, SQLExecDirect, hstmt,
 	    ConvertToSQLCHAR(
 	        "SELECT regexp_matches(user_agent, '^duckdb/.*(.*) odbc CUSTOM_STRING') FROM pragma_user_agent()"),
 	    SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (get user_agent)", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "true");
 
 	// Free the env handle
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -255,22 +255,22 @@ TEST_CASE("Connect with named file, disconnect and reconnect", "[odbc]") {
 	// Connect to the database using SQLConnect
 	DRIVER_CONNECT_TO_DATABASE(env, dbc, "Database=test_odbc_named.db");
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// create a table
-	EXECUTE_AND_CHECK("SQLExecDirect (create table)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (create table)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("CREATE OR REPLACE TABLE test_table (a INTEGER)"), SQL_NTS);
 
 	// insert a row
-	EXECUTE_AND_CHECK("SQLExecDirect (insert row)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (insert row)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("INSERT INTO test_table VALUES (1)"), SQL_NTS);
 
 	// select the row
-	EXECUTE_AND_CHECK("SQLExecDirect (select row)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
+	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
 	                  SQL_NTS);
 
 	// Fetch the result
-	EXECUTE_AND_CHECK("SQLFetch (select row)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (select row)", hstmt, SQLFetch, hstmt);
 
 	// Check the result
 	DATA_CHECK(hstmt, 1, "1");
@@ -282,14 +282,14 @@ TEST_CASE("Connect with named file, disconnect and reconnect", "[odbc]") {
 	DRIVER_CONNECT_TO_DATABASE(env, dbc, "Database=test_odbc_named.db");
 
 	hstmt = SQL_NULL_HSTMT;
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// select the row
-	EXECUTE_AND_CHECK("SQLExecDirect (select row)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
+	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
 	                  SQL_NTS);
 
 	// Fetch the result
-	EXECUTE_AND_CHECK("SQLFetch (select row)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (select row)", hstmt, SQLFetch, hstmt);
 
 	// Check the result
 	DATA_CHECK(hstmt, 1, "1");

--- a/test/tests/connect.cpp
+++ b/test/tests/connect.cpp
@@ -21,8 +21,8 @@ void ConnectWithoutDSN(SQLHANDLE &env, SQLHANDLE &dbc) {
 
 	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
-	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS,
-	                  str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
+	EXECUTE_AND_CHECK("SQLDriverConnect", nullptr, SQLDriverConnect, dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()),
+	                  SQL_NTS, str, sizeof(str), &strl, SQL_DRIVER_COMPLETE);
 }
 
 // Connect to a database with extra keywords provided by Power Query SDK
@@ -266,8 +266,8 @@ TEST_CASE("Connect with named file, disconnect and reconnect", "[odbc]") {
 	                  ConvertToSQLCHAR("INSERT INTO test_table VALUES (1)"), SQL_NTS);
 
 	// select the row
-	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT * FROM test_table"), SQL_NTS);
 
 	// Fetch the result
 	EXECUTE_AND_CHECK("SQLFetch (select row)", hstmt, SQLFetch, hstmt);
@@ -285,8 +285,8 @@ TEST_CASE("Connect with named file, disconnect and reconnect", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// select the row
-	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_table"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (select row)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT * FROM test_table"), SQL_NTS);
 
 	// Fetch the result
 	EXECUTE_AND_CHECK("SQLFetch (select row)", hstmt, SQLFetch, hstmt);

--- a/test/tests/cte.cpp
+++ b/test/tests/cte.cpp
@@ -31,8 +31,8 @@ static void PreparedWithTest(HSTMT &hstmt) {
 
 	SQLINTEGER param = 3;
 	SQLLEN param_len = sizeof(param);
-	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_INTEGER, SQL_INTEGER, 0, 0,
-	                  &param, sizeof(param), &param_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_INTEGER, SQL_INTEGER,
+	                  0, 0, &param, sizeof(param), &param_len);
 
 	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 

--- a/test/tests/cte.cpp
+++ b/test/tests/cte.cpp
@@ -4,7 +4,7 @@ using namespace odbc_test;
 
 static void RunDataCheckOnTable(HSTMT &hstmt, int num_rows) {
 	for (int i = 1; i <= num_rows; i++) {
-		EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 		DATA_CHECK(hstmt, 1, std::to_string(i));
 		DATA_CHECK(hstmt, 2, std::string("foo") + std::to_string(i));
 	}
@@ -12,33 +12,33 @@ static void RunDataCheckOnTable(HSTMT &hstmt, int num_rows) {
 
 // Test Simple With Query
 static void SimpleWithTest(HSTMT &hstmt) {
-	EXECUTE_AND_CHECK("SQLExectDirect(WITH)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExectDirect(WITH)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("with recursive cte as (select g, 'foo' || g as foocol from "
 	                                   "generate_series(1,10) as g(g)) select * from cte;"),
 	                  SQL_NTS);
 
 	RunDataCheckOnTable(hstmt, 10);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt(CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt(CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 // Test With Query with Prepare and Execute
 static void PreparedWithTest(HSTMT &hstmt) {
-	EXECUTE_AND_CHECK("SQLPrepare(WITH)", SQLPrepare, hstmt,
+	EXECUTE_AND_CHECK("SQLPrepare(WITH)", hstmt, SQLPrepare, hstmt,
 	                  ConvertToSQLCHAR("with cte as (select g, 'foo' || g as foocol from generate_series(1,10) as "
 	                                   "g(g)) select * from cte WHERE g < ?"),
 	                  SQL_NTS);
 
 	SQLINTEGER param = 3;
 	SQLLEN param_len = sizeof(param);
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_INTEGER, SQL_INTEGER, 0, 0,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_INTEGER, SQL_INTEGER, 0, 0,
 	                  &param, sizeof(param), &param_len);
 
-	EXECUTE_AND_CHECK("SQLExecute", SQLExecute, hstmt);
+	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 
 	RunDataCheckOnTable(hstmt, 2);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt(CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt(CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 /**
@@ -54,14 +54,14 @@ TEST_CASE("Test CTE", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	SimpleWithTest(hstmt);
 	PreparedWithTest(hstmt);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/cursor_commit.cpp
+++ b/test/tests/cursor_commit.cpp
@@ -9,23 +9,23 @@ static void SimpleCursorCommitTest(SQLHANDLE dbc) {
 	HSTMT hstmt = SQL_NULL_HSTMT;
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
-	EXECUTE_AND_CHECK("SQLSetStmtAttr", SQLSetStmtAttr, hstmt, SQL_ATTR_CURSOR_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_CURSOR_TYPE,
 	                  ConvertToSQLPOINTER(SQL_CURSOR_STATIC), SQL_IS_UINTEGER);
 
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT g FROM generate_series(1,3) g(g)"), SQL_NTS);
 
 	char buf[1024];
 	SQLLEN buf_len;
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt, 1, SQL_C_CHAR, &buf, sizeof(buf), &buf_len);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt, SQLBindCol, hstmt, 1, SQL_C_CHAR, &buf, sizeof(buf), &buf_len);
 
 	// Commit. This implicitly closes the cursor in the server.
-	EXECUTE_AND_CHECK("SQLEndTran", SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
+	EXECUTE_AND_CHECK("SQLEndTran", hstmt, SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
 
 	for (char i = 1; i < 4; i++) {
-		EXECUTE_AND_CHECK("SQLFetchScroll", SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
+		EXECUTE_AND_CHECK("SQLFetchScroll", hstmt, SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
 		REQUIRE(buf_len == 1);
 		REQUIRE(STR_EQUAL(buf, std::to_string(i).c_str()));
 	}
@@ -33,27 +33,27 @@ static void SimpleCursorCommitTest(SQLHANDLE dbc) {
 	SQLRETURN ret = SQLFetchScroll(hstmt, SQL_FETCH_NEXT, 0);
 	REQUIRE(ret == SQL_NO_DATA);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 }
 
 static void PreparedCursorCommitTest(SQLHANDLE dbc) {
 	HSTMT hstmt = SQL_NULL_HSTMT;
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Try to commit without an open query
-	EXECUTE_AND_CHECK("SQLEndTran", SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
+	EXECUTE_AND_CHECK("SQLEndTran", hstmt, SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
 
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::BOOL"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::BOOL"), SQL_NTS);
 
 	// Commit with a prepared statement
-	EXECUTE_AND_CHECK("SQLEndTran", SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
+	EXECUTE_AND_CHECK("SQLEndTran", hstmt, SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 }
 
 static void MultipleHSTMTTest(SQLHANDLE dbc) {
@@ -61,30 +61,30 @@ static void MultipleHSTMTTest(SQLHANDLE dbc) {
 	HSTMT hstmt2 = SQL_NULL_HSTMT;
 
 	// Allocate a statement handles
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt1);
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt2);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt1, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt1);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt2, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt2);
 
 	// Execute queries on both statement handles
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt1,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt1, SQLExecDirect, hstmt1,
 	                  ConvertToSQLCHAR("SELECT g FROM generate_series(1,3) g(g)"), SQL_NTS);
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt2,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt2, SQLExecDirect, hstmt2,
 	                  ConvertToSQLCHAR("SELECT g FROM generate_series(1,3) g(g)"), SQL_NTS);
 
 	// Free first statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt1, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt1);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", nullptr, SQLFreeStmt, hstmt1, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", nullptr, SQLFreeHandle, SQL_HANDLE_STMT, hstmt1);
 
 	// Commit test after the first handle is released
-	EXECUTE_AND_CHECK("SQLEndTran", SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
+	EXECUTE_AND_CHECK("SQLEndTran", nullptr, SQLEndTran, SQL_HANDLE_DBC, dbc, SQL_COMMIT);
 
 	SQLINTEGER buf;
 	SQLLEN buf_len;
 
-	EXECUTE_AND_CHECK("SQLBindCol", SQLBindCol, hstmt2, 1, SQL_C_SLONG, &buf, sizeof(buf), &buf_len);
+	EXECUTE_AND_CHECK("SQLBindCol", hstmt2, SQLBindCol, hstmt2, 1, SQL_C_SLONG, &buf, sizeof(buf), &buf_len);
 
 	// Fetch from the second statement handle
 	for (int i = 1; i < 4; i++) {
-		EXECUTE_AND_CHECK("SQLFetchScroll", SQLFetchScroll, hstmt2, SQL_FETCH_NEXT, 0);
+		EXECUTE_AND_CHECK("SQLFetchScroll", hstmt2, SQLFetchScroll, hstmt2, SQL_FETCH_NEXT, 0);
 		REQUIRE(buf_len == sizeof(buf));
 		REQUIRE(buf == i);
 	}
@@ -93,8 +93,8 @@ static void MultipleHSTMTTest(SQLHANDLE dbc) {
 	REQUIRE(ret == SQL_NO_DATA);
 
 	// Free second statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt2, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt2);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", nullptr, SQLFreeStmt, hstmt2, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", nullptr, SQLFreeHandle, SQL_HANDLE_STMT, hstmt2);
 }
 
 // These tests are related to cursor commit behavior.
@@ -106,7 +106,7 @@ TEST_CASE("Test setting cursor attributes, and closing the cursor", "[odbc]") {
 	// Connect to the database using SQLConnect
 	CONNECT_TO_DATABASE(env, dbc);
 
-	EXECUTE_AND_CHECK("SQLSetConnectAttr", SQLSetConnectAttr, dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_OFF,
+	EXECUTE_AND_CHECK("SQLSetConnectAttr", nullptr, SQLSetConnectAttr, dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_OFF,
 	                  SQL_IS_INTEGER);
 
 	SimpleCursorCommitTest(dbc);

--- a/test/tests/cursor_commit.cpp
+++ b/test/tests/cursor_commit.cpp
@@ -106,8 +106,8 @@ TEST_CASE("Test setting cursor attributes, and closing the cursor", "[odbc]") {
 	// Connect to the database using SQLConnect
 	CONNECT_TO_DATABASE(env, dbc);
 
-	EXECUTE_AND_CHECK("SQLSetConnectAttr", nullptr, SQLSetConnectAttr, dbc, SQL_ATTR_AUTOCOMMIT, (SQLPOINTER)SQL_AUTOCOMMIT_OFF,
-	                  SQL_IS_INTEGER);
+	EXECUTE_AND_CHECK("SQLSetConnectAttr", nullptr, SQLSetConnectAttr, dbc, SQL_ATTR_AUTOCOMMIT,
+	                  (SQLPOINTER)SQL_AUTOCOMMIT_OFF, SQL_IS_INTEGER);
 
 	SimpleCursorCommitTest(dbc);
 	PreparedCursorCommitTest(dbc);

--- a/test/tests/data_execution.cpp
+++ b/test/tests/data_execution.cpp
@@ -16,8 +16,8 @@ static void DataAtExecution(HSTMT &hstmt) {
 	                  param_1_bytes, 0, ConvertToSQLPOINTER(1), 0, &param_1_len);
 
 	SQLLEN param_2_len = SQL_DATA_AT_EXEC;
-	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR, 6, 0,
-	                  ConvertToSQLPOINTER(2), 0, &param_2_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR,
+	                  6, 0, ConvertToSQLPOINTER(2), 0, &param_2_len);
 
 	// Execute the statement
 	SQLRETURN ret = SQLExecute(hstmt);
@@ -52,22 +52,22 @@ static void ArrayBindingDataAtExecution(HSTMT &hstmt) {
 	SQLULEN num_processed;
 
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id FROM bytea_table WHERE t = ?"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+	                  ConvertToSQLCHAR("SELECT id FROM bytea_table WHERE t = ?"), SQL_NTS);
 
 	// Set STMT attributes PARAM_BIND_TYPE, PARAM_STATUS_PTR, PARAMS_PROCESSED_PTR, and PARAMSET_SIZE
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
-	                  reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
-	                  status, 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_PARAM_BIND_TYPE, reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_PARAM_STATUS_PTR, status, 0);
 	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMS_PROCESSED_PTR)", hstmt, SQLSetStmtAttr, hstmt,
 	                  SQL_ATTR_PARAMS_PROCESSED_PTR, &num_processed, 0);
 	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMSET_SIZE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAMSET_SIZE,
 	                  ConvertToSQLPOINTER(2), 0);
 
 	// Bind the array
-	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 5,
-	                  0, ConvertToSQLPOINTER(1), 0, str_ind);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY,
+	                  SQL_VARBINARY, 5, 0, ConvertToSQLPOINTER(1), 0, str_ind);
 
 	// Execute the statement
 	SQLRETURN ret = SQLExecute(hstmt);

--- a/test/tests/data_execution.cpp
+++ b/test/tests/data_execution.cpp
@@ -6,17 +6,17 @@ using namespace odbc_test;
 
 static void DataAtExecution(HSTMT &hstmt) {
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", SQLPrepare, hstmt,
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
 	                  ConvertToSQLCHAR("SELECT id FROM bytea_table WHERE t = ? OR t = ?"), SQL_NTS);
 
 	SQLCHAR *param_1 = ConvertToSQLCHAR("bar");
 	SQLLEN param_1_bytes = strlen(ConvertToCString(param_1));
 	SQLLEN param_1_len = SQL_DATA_AT_EXEC;
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR,
 	                  param_1_bytes, 0, ConvertToSQLPOINTER(1), 0, &param_1_len);
 
 	SQLLEN param_2_len = SQL_DATA_AT_EXEC;
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR, 6, 0,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARCHAR, 6, 0,
 	                  ConvertToSQLPOINTER(2), 0, &param_2_len);
 
 	// Execute the statement
@@ -27,23 +27,23 @@ static void DataAtExecution(HSTMT &hstmt) {
 	SQLPOINTER param_id = nullptr;
 	while ((ret = SQLParamData(hstmt, &param_id)) == SQL_NEED_DATA) {
 		if (param_id == ConvertToSQLPOINTER(1)) {
-			EXECUTE_AND_CHECK("SQLPutData", SQLPutData, hstmt, param_1, param_1_bytes);
+			EXECUTE_AND_CHECK("SQLPutData", hstmt, SQLPutData, hstmt, param_1, param_1_bytes);
 		} else if (param_id == ConvertToSQLPOINTER(2)) {
-			EXECUTE_AND_CHECK("SQLPutData", SQLPutData, hstmt, ConvertToSQLPOINTER("foo"), 3);
-			EXECUTE_AND_CHECK("SQLPutData", SQLPutData, hstmt, ConvertToSQLPOINTER("bar"), 3);
+			EXECUTE_AND_CHECK("SQLPutData", hstmt, SQLPutData, hstmt, ConvertToSQLPOINTER("foo"), 3);
+			EXECUTE_AND_CHECK("SQLPutData", hstmt, SQLPutData, hstmt, ConvertToSQLPOINTER("bar"), 3);
 		} else {
 			FAIL("Unexpected parameter id");
 		}
 	}
-	ODBC_CHECK(ret, "SQLParamData");
+	ODBC_CHECK(ret, "SQLParamData", hstmt);
 
 	// Fetch the results
 	for (int i = 2; i < 4; i++) {
-		EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 		DATA_CHECK(hstmt, 0, std::to_string(i));
 	}
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 static void ArrayBindingDataAtExecution(HSTMT &hstmt) {
@@ -52,21 +52,21 @@ static void ArrayBindingDataAtExecution(HSTMT &hstmt) {
 	SQLULEN num_processed;
 
 	// Prepare a statement
-	EXECUTE_AND_CHECK("SQLPrepare", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id FROM bytea_table WHERE t = ?"),
+	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT id FROM bytea_table WHERE t = ?"),
 	                  SQL_NTS);
 
 	// Set STMT attributes PARAM_BIND_TYPE, PARAM_STATUS_PTR, PARAMS_PROCESSED_PTR, and PARAMSET_SIZE
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
 	                  reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAM_STATUS_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
 	                  status, 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMS_PROCESSED_PTR)", SQLSetStmtAttr, hstmt,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMS_PROCESSED_PTR)", hstmt, SQLSetStmtAttr, hstmt,
 	                  SQL_ATTR_PARAMS_PROCESSED_PTR, &num_processed, 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMSET_SIZE)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAMSET_SIZE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr(SQL_ATTR_PARAMSET_SIZE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAMSET_SIZE,
 	                  ConvertToSQLPOINTER(2), 0);
 
 	// Bind the array
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 5,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_BINARY, SQL_VARBINARY, 5,
 	                  0, ConvertToSQLPOINTER(1), 0, str_ind);
 
 	// Execute the statement
@@ -77,14 +77,14 @@ static void ArrayBindingDataAtExecution(HSTMT &hstmt) {
 	SQLPOINTER param_id = nullptr;
 	while ((ret = SQLParamData(hstmt, &param_id)) == SQL_NEED_DATA) {
 		if (num_processed == 1) {
-			EXECUTE_AND_CHECK("SQLPutData", SQLPutData, hstmt, ConvertToSQLPOINTER("foo"), 3);
+			EXECUTE_AND_CHECK("SQLPutData", hstmt, SQLPutData, hstmt, ConvertToSQLPOINTER("foo"), 3);
 		} else if (num_processed == 2) {
-			EXECUTE_AND_CHECK("SQLPutData", SQLPutData, hstmt, ConvertToSQLPOINTER("barf"), 4);
+			EXECUTE_AND_CHECK("SQLPutData", hstmt, SQLPutData, hstmt, ConvertToSQLPOINTER("barf"), 4);
 		} else {
 			FAIL("Unexpected parameter id");
 		}
 	}
-	ODBC_CHECK(ret, "SQLParamData");
+	ODBC_CHECK(ret, "SQLParamData", hstmt);
 
 	for (int i = 0; i < num_processed; i++) {
 		REQUIRE(status[i] == SQL_PARAM_SUCCESS);
@@ -92,14 +92,14 @@ static void ArrayBindingDataAtExecution(HSTMT &hstmt) {
 
 	// Fetch the results
 	for (int i = 4; i; i++) {
-		EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 		DATA_CHECK(hstmt, 0, std::to_string(i));
 
 		ret = SQLMoreResults(hstmt);
 		if (ret == SQL_NO_DATA) {
 			break;
 		} else if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) {
-			ODBC_CHECK(ret, "SQLMoreResults");
+			ODBC_CHECK(ret, "SQLMoreResults", hstmt);
 		}
 	}
 	REQUIRE(SQLFetch(hstmt) == SQL_NO_DATA);
@@ -115,7 +115,7 @@ TEST_CASE("Test SQLBindParameter, SQLParamData, and SQLPutData", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	InitializeDatabase(hstmt);
 
@@ -126,8 +126,8 @@ TEST_CASE("Test SQLBindParameter, SQLParamData, and SQLPutData", "[odbc]") {
 	ArrayBindingDataAtExecution(hstmt);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -143,7 +143,7 @@ TEST_CASE("PIVOT statement", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	EXEC_SQL(hstmt, "CREATE TABLE Cities (Country VARCHAR, Name VARCHAR, Year INT, Population INT);");
 	EXEC_SQL(hstmt, "INSERT INTO Cities VALUES ('NL', 'Amsterdam', 2000, 1005);");
@@ -167,19 +167,19 @@ TEST_CASE("PIVOT statement", "[odbc]") {
 		FAIL("SQLExecDirect failed with state: " + state + " and message: " + message);
 	}
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "NL");
 	DATA_CHECK(hstmt, 2, "Amsterdam");
 	DATA_CHECK(hstmt, 3, "1005");
 	DATA_CHECK(hstmt, 4, "1065");
 	DATA_CHECK(hstmt, 5, "1158");
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "US");
 	DATA_CHECK(hstmt, 2, "New York City");
 	DATA_CHECK(hstmt, 3, "8015");
 	DATA_CHECK(hstmt, 4, "8175");
 	DATA_CHECK(hstmt, 5, "8772");
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "US");
 	DATA_CHECK(hstmt, 2, "Seattle");
 	DATA_CHECK(hstmt, 3, "564");
@@ -187,8 +187,8 @@ TEST_CASE("PIVOT statement", "[odbc]") {
 	DATA_CHECK(hstmt, 5, "738");
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/declare_fetch_block.cpp
+++ b/test/tests/declare_fetch_block.cpp
@@ -34,7 +34,8 @@ static void BlockCursor(HSTMT &hstmt, ESize S, SQLINTEGER *&id, SQLLEN *&id_ind)
 	EXECUTE_AND_CHECK("SQLBindCol (id)", hstmt, SQLBindCol, hstmt, 1, SQL_C_SLONG, id, 0, id_ind);
 
 	// Execute the query
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test"),
+	                  SQL_NTS);
 
 	int expected_rows_fetched = 0;
 	if (S == SMALL) {
@@ -89,7 +90,8 @@ static void ScrollNext(HSTMT &hstmt, ESize S) {
 	REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
 
 	// Execute the query
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test"),
+	                  SQL_NTS);
 
 	// Fetch results using SQLFetchScroll
 	for (int i = 0; i < 2; i++) {

--- a/test/tests/diagnostics.cpp
+++ b/test/tests/diagnostics.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Test SQLGetDiagRec (returns diagnostic record)", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	/* TEST 1: Execute a query that will fail and check the diagnostics */
 	// Execute a query that will fail
@@ -87,8 +87,8 @@ TEST_CASE("Test SQLGetDiagRec (returns diagnostic record)", "[odbc]") {
 	REQUIRE(first_endtran_message.length() == static_cast<size_t>(text_length));
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/extension.cpp
+++ b/test/tests/extension.cpp
@@ -14,24 +14,24 @@ TEST_CASE("Test Extension", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", nullptr, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Install and load the httpfs extension
-	EXECUTE_AND_CHECK("INSTALL httpfs", SQLExecDirect, hstmt, ConvertToSQLCHAR("INSTALL httpfs"), SQL_NTS);
+	EXECUTE_AND_CHECK("INSTALL httpfs", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("INSTALL httpfs"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("LOAD httpfs", SQLExecDirect, hstmt, ConvertToSQLCHAR("LOAD httpfs"), SQL_NTS);
+	EXECUTE_AND_CHECK("LOAD httpfs", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("LOAD httpfs"), SQL_NTS);
 
 	// Check if the extension is loaded
 	EXEC_SQL(hstmt, "SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs'");
 
 	// Should return true
-	EXECUTE_AND_CHECK("SQLFetch (SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs')", SQLFetch,
-	                  hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (SELECT LOADED FROM duckdb_extensions() WHERE extension_name = 'httpfs')", hstmt,
+	                  SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, "true");
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -46,25 +46,24 @@ TEST_CASE("Log DuckDB Version", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Get the version of DuckDB
-	EXECUTE_AND_CHECK("PRAGMA version", SQLExecDirect, hstmt, ConvertToSQLCHAR("PRAGMA version"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("PRAGMA version", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("PRAGMA version"), SQL_NTS);
 
 	// Fetch the results
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	SQLCHAR content[256];
 	SQLLEN content_len;
 
 	// SQLGetData returns data for a single column in the result set.
 	SQLRETURN ret = SQLGetData(hstmt, 2, SQL_C_CHAR, content, sizeof(content), &content_len);
-	ODBC_CHECK(ret, "SQLGetData");
+	ODBC_CHECK(ret, "SQLGetData", hstmt);
 	std::cout << "Version: " << ConvertToString(content) << std::endl;
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/multicolumn_param_bind.cpp
+++ b/test/tests/multicolumn_param_bind.cpp
@@ -15,33 +15,33 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Create a table
-	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (CREATE TABLE)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("CREATE TABLE test_tbl (Column1 VARCHAR(100), Column2 VARCHAR(100))"), SQL_NTS);
 
 	// Free and re-allocate the statement handle to clear the statement
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Set the SQL_ATTR_PARAM_BIND_TYPE statement attribute to use column-wise binding.
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
 	                  reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
 
 	// Specify an array in which to return the status of each set of parameters.
 	SQLUSMALLINT param_status[MAX_INSERT_COUNT];
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_STATUS_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
 	                  param_status, 0);
 
 	// Specify an SQLULEN value into which to return the number of sets of parameters processed.
 	SQLULEN params_processed;
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAMS_PROCESSED_PTR)", SQLSetStmtAttr, hstmt,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAMS_PROCESSED_PTR)", hstmt, SQLSetStmtAttr, hstmt,
 	                  SQL_ATTR_PARAMS_PROCESSED_PTR, &params_processed, 0);
 
 	// Specify the number of parameter sets to be processed before execution occurs.
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAMSET_SIZE)", SQLSetStmtAttr, hstmt, SQL_ATTR_PARAMSET_SIZE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAMSET_SIZE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAMSET_SIZE,
 	                  ConvertToSQLPOINTER(MAX_INSERT_COUNT), 0);
 
 	const char *c1_r1 = "John Doe", *c1_r2 = "Jane Doe";
@@ -59,13 +59,13 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 	memcpy(c2[1], c2_r2, c2_ind[1]);
 
 	// Bind the parameters in column-wise fashion.
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
 	                  MAX_BUFFER_SIZE - 1, 0, c1, MAX_BUFFER_SIZE, c1_ind);
-	EXECUTE_AND_CHECK("SQLBindParameter", SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
 	                  MAX_BUFFER_SIZE - 1, 0, c2, MAX_BUFFER_SIZE, c2_ind);
 
 	// Execute the statement
-	EXECUTE_AND_CHECK("SQLExecDirect (INSERT)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (INSERT)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("INSERT INTO test_tbl (Column1, Column2) VALUES (?, ?)"), SQL_NTS);
 
 	// Verify that the correct number of parameter sets were processed.
@@ -74,10 +74,10 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 	}
 
 	// Close the cursor
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 
 	// Get the data back and verify it
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_tbl"),
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM test_tbl"),
 	                  SQL_NTS);
 
 	std::string col_name[2] = {"Column1", "Column2"};
@@ -88,16 +88,16 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 		if (ret == SQL_NO_DATA) {
 			break;
 		}
-		ODBC_CHECK(ret, "SQLFetch");
+		ODBC_CHECK(ret, "SQLFetch", hstmt);
 		for (int j = 0; j < params_processed; j++) {
-			EXECUTE_AND_CHECK("SQLGetData", SQLGetData, hstmt, 1, SQL_C_CHAR, c1[j], MAX_BUFFER_SIZE, &c1_ind[j]);
-			EXECUTE_AND_CHECK("SQLGetData", SQLGetData, hstmt, 2, SQL_C_CHAR, c2[j], MAX_BUFFER_SIZE, &c2_ind[j]);
+			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_CHAR, c1[j], MAX_BUFFER_SIZE, &c1_ind[j]);
+			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, c2[j], MAX_BUFFER_SIZE, &c2_ind[j]);
 		}
 	}
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/multicolumn_param_bind.cpp
+++ b/test/tests/multicolumn_param_bind.cpp
@@ -27,13 +27,13 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Set the SQL_ATTR_PARAM_BIND_TYPE statement attribute to use column-wise binding.
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_BIND_TYPE,
-	                  reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_PARAM_BIND_TYPE, reinterpret_cast<SQLPOINTER>(SQL_PARAM_BIND_BY_COLUMN), 0);
 
 	// Specify an array in which to return the status of each set of parameters.
 	SQLUSMALLINT param_status[MAX_INSERT_COUNT];
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_PARAM_STATUS_PTR,
-	                  param_status, 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_PARAM_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_PARAM_STATUS_PTR, param_status, 0);
 
 	// Specify an SQLULEN value into which to return the number of sets of parameters processed.
 	SQLULEN params_processed;
@@ -90,8 +90,10 @@ TEST_CASE("Test binding multiple columsn at once", "[odbc]") {
 		}
 		ODBC_CHECK(ret, "SQLFetch", hstmt);
 		for (int j = 0; j < params_processed; j++) {
-			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_CHAR, c1[j], MAX_BUFFER_SIZE, &c1_ind[j]);
-			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, c2[j], MAX_BUFFER_SIZE, &c2_ind[j]);
+			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_CHAR, c1[j], MAX_BUFFER_SIZE,
+			                  &c1_ind[j]);
+			EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, c2[j], MAX_BUFFER_SIZE,
+			                  &c2_ind[j]);
 		}
 	}
 

--- a/test/tests/numeric.cpp
+++ b/test/tests/numeric.cpp
@@ -44,14 +44,14 @@ static void TestNumericParams(HSTMT &hstmt, unsigned char sign, const char *hexv
 	BuildNumericStruct(&numeric, sign, hexval, precision, scale);
 
 	SQLLEN numeric_len = sizeof(numeric);
-	EXECUTE_AND_CHECK("SQLBindParameter (numeric)", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_NUMERIC,
+	EXECUTE_AND_CHECK("SQLBindParameter (numeric)", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_NUMERIC,
 	                  SQL_NUMERIC, precision, scale, &numeric, numeric_len, &numeric_len);
 
-	EXECUTE_AND_CHECK("SQLExecute", SQLExecute, hstmt);
+	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	DATA_CHECK(hstmt, 1, expected);
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 static void TestNumericResult(HSTMT &hstmt, const char *num_str, const std::string &expected_result,
@@ -61,10 +61,10 @@ static void TestNumericResult(HSTMT &hstmt, const char *num_str, const std::stri
 
 	std::string query = "SELECT '" + std::string(num_str) + "'::numeric(" + std::to_string(precision) + "," +
 	                    std::to_string(scale) + ")";
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
-	EXECUTE_AND_CHECK("SQLGetData", SQLGetData, hstmt, 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), nullptr);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_NUMERIC, &numeric, sizeof(numeric), nullptr);
 	REQUIRE(numeric.precision == expected_precision);
 	REQUIRE(numeric.scale == expected_scale);
 	REQUIRE(numeric.sign == 1);
@@ -81,25 +81,25 @@ TEST_CASE("Test numeric limits and conversion", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Test 25.212 with default precision and scale
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric)", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric)", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric"), SQL_NTS);
 	TestNumericParams(hstmt, 1, "7C62", 5, 3, "25.212");
 
 	// Test 0 (negative and positive) with precision 1 and scale 0
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(1,0))", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(1,0)"),
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(1,0))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(1,0)"),
 	                  SQL_NTS);
 	TestNumericParams(hstmt, 1, "00", 1, 0, "0");
 	TestNumericParams(hstmt, 0, "00", 1, 0, "0");
 
 	// Test 7.70 with precision 3 and scale 2
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(3,2))", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(3,2)"),
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(3,2))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(3,2)"),
 	                  SQL_NTS);
 	TestNumericParams(hstmt, 1, "0203", 3, 2, "7.70");
 
 	// Test 12345678901234567890123456789012345678 with precision 38 and scale 0
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(38,0))", SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(38,0)"),
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(38,0))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(38,0)"),
 	                  SQL_NTS);
 	TestNumericParams(hstmt, 1, "4EF338DE509049C4133302F0F6B04909", 38, 0, "12345678901234567890123456789012345678");
 
@@ -113,8 +113,8 @@ TEST_CASE("Test numeric limits and conversion", "[odbc]") {
 	TestNumericResult(hstmt, "999999999999", "FF0FA5D4E8000000", 12, 3);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/numeric.cpp
+++ b/test/tests/numeric.cpp
@@ -84,23 +84,24 @@ TEST_CASE("Test numeric limits and conversion", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Test 25.212 with default precision and scale
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric)", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric)", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric"),
+	                  SQL_NTS);
 	TestNumericParams(hstmt, 1, "7C62", 5, 3, "25.212");
 
 	// Test 0 (negative and positive) with precision 1 and scale 0
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(1,0))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(1,0)"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(1,0))", hstmt, SQLPrepare, hstmt,
+	                  ConvertToSQLCHAR("SELECT ?::numeric(1,0)"), SQL_NTS);
 	TestNumericParams(hstmt, 1, "00", 1, 0, "0");
 	TestNumericParams(hstmt, 0, "00", 1, 0, "0");
 
 	// Test 7.70 with precision 3 and scale 2
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(3,2))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(3,2)"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(3,2))", hstmt, SQLPrepare, hstmt,
+	                  ConvertToSQLCHAR("SELECT ?::numeric(3,2)"), SQL_NTS);
 	TestNumericParams(hstmt, 1, "0203", 3, 2, "7.70");
 
 	// Test 12345678901234567890123456789012345678 with precision 38 and scale 0
-	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(38,0))", hstmt, SQLPrepare, hstmt, ConvertToSQLCHAR("SELECT ?::numeric(38,0)"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLPrepare (?::numeric(38,0))", hstmt, SQLPrepare, hstmt,
+	                  ConvertToSQLCHAR("SELECT ?::numeric(38,0)"), SQL_NTS);
 	TestNumericParams(hstmt, 1, "4EF338DE509049C4133302F0F6B04909", 38, 0, "12345678901234567890123456789012345678");
 
 	// Test setting numeric struct within the application

--- a/test/tests/quotes.cpp
+++ b/test/tests/quotes.cpp
@@ -9,8 +9,8 @@ static void BindParamAndExecute(HSTMT &hstmt, SQLCHAR *query, SQLCHAR *param,
                                 const std::vector<std::string> &expected_result) {
 	SQLLEN len = strlen((char *)param);
 
-	EXECUTE_AND_CHECK("SQLBindParameter (param)", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR, 20,
-	                  0, param, len, &len);
+	EXECUTE_AND_CHECK("SQLBindParameter (param)", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+	                  SQL_CHAR, 20, 0, param, len, &len);
 
 	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, query, SQL_NTS);
 

--- a/test/tests/quotes.cpp
+++ b/test/tests/quotes.cpp
@@ -9,17 +9,17 @@ static void BindParamAndExecute(HSTMT &hstmt, SQLCHAR *query, SQLCHAR *param,
                                 const std::vector<std::string> &expected_result) {
 	SQLLEN len = strlen((char *)param);
 
-	EXECUTE_AND_CHECK("SQLBindParameter (param)", SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR, 20,
+	EXECUTE_AND_CHECK("SQLBindParameter (param)", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_CHAR, 20,
 	                  0, param, len, &len);
 
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt, query, SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, query, SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	for (int i = 0; i < expected_result.size(); i++) {
 		DATA_CHECK(hstmt, i + 1, expected_result[i]);
 	}
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 TEST_CASE("Test parameter quoting and in combination with special characters", "[odbc]") {
@@ -32,7 +32,7 @@ TEST_CASE("Test parameter quoting and in combination with special characters", "
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Check that the driver escapes quotes correctly
 	BindParamAndExecute(hstmt, ConvertToSQLCHAR("SELECT 'foo', ?::text"), ConvertToSQLCHAR("param'quote"),
@@ -64,8 +64,8 @@ TEST_CASE("Test parameter quoting and in combination with special characters", "
 	                    ConvertToSQLCHAR("param"), {"1", "param", "2 $'s in an identifier"});
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/result_conversion.cpp
+++ b/test/tests/result_conversion.cpp
@@ -516,9 +516,9 @@ static void ConvertAndCheck(HSTMT &hstmt, const std::string &type, const std::st
                             SQLINTEGER sql_type, const std::string &expected_result, int content_size = 256) {
 	std::string query = "SELECT $$" + type_to_convert + "$$::" + type;
 
-	EXECUTE_AND_CHECK(query.c_str(), SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
+	EXECUTE_AND_CHECK(query.c_str(), hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	SQLCHAR content[256];
 	SQLLEN content_len;
 	SQLRETURN ret = SQLGetData(hstmt, 1, sql_type, content, content_size, &content_len);
@@ -531,7 +531,7 @@ static void ConvertAndCheck(HSTMT &hstmt, const std::string &type, const std::st
 	}
 	ConvertToTypes(sql_type, content, expected_result);
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 }
 
 TEST_CASE("Test converting using SQLGetData", "[odbc]") {
@@ -544,7 +544,7 @@ TEST_CASE("Test converting using SQLGetData", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	for (int type_index = 0; type_index < all_types.size(); type_index++) {
 		for (int sql_type_index = 0; sql_type_index < all_sql_types.size(); sql_type_index++) {
@@ -589,8 +589,8 @@ TEST_CASE("Test converting using SQLGetData", "[odbc]") {
 	ConvertAndCheck(hstmt, "timestamp_ns", "2021-07-15 12:30:00", SQL_C_TYPE_TIMESTAMP, "2021-7-15-12-30-0-0");
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -605,21 +605,21 @@ TEST_CASE("Test SQLGetData with SQL_C_DEFAULT type", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Run the query
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT CAST(42 AS BIGINT)"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT CAST(42 AS BIGINT)"), SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	SQLSMALLINT value = 0;
 	SQLLEN out_len;
-	EXECUTE_AND_CHECK("SQLGetData", SQLGetData, hstmt, 1, SQL_C_DEFAULT, &value, sizeof(value), &out_len);
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_DEFAULT, &value, sizeof(value), &out_len);
 	REQUIRE(42 == value);
 	REQUIRE(2 == out_len);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/result_conversion.cpp
+++ b/test/tests/result_conversion.cpp
@@ -608,7 +608,8 @@ TEST_CASE("Test SQLGetData with SQL_C_DEFAULT type", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Run the query
-	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT CAST(42 AS BIGINT)"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT CAST(42 AS BIGINT)"),
+	                  SQL_NTS);
 
 	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	SQLSMALLINT value = 0;

--- a/test/tests/row_wise_fetching.cpp
+++ b/test/tests/row_wise_fetching.cpp
@@ -35,8 +35,8 @@ static void TestRowWiseExampleTable(HSTMT &hstmt) {
 	                  reinterpret_cast<SQLPOINTER>(ROW_ARRAY_SIZE), 0);
 	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_STATUS_PTR,
 	                  row_array_status, 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
-	                  &rows_fetched, 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
 	// Bind elements of the first structure in the array to the OrderID,
 	// SalesPerson, and Status columns.
@@ -106,8 +106,8 @@ void TestManySQLTypes(HSTMT &hstmt) {
 	                  row_array_status, 0);
 	// Specify the address of the variable that will receive the number of rows fetched with the
 	// SQL_ATTR_ROWS_FETCHED_PTR
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
-	                  &rows_fetched, 0);
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt,
+	                  SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
 	// Bind elements of the first structure to the array
 	EXECUTE_AND_CHECK("SQLBindCol (b)", hstmt, SQLBindCol, hstmt, 1, SQL_C_CHAR, many_sql_types[0].b,

--- a/test/tests/row_wise_fetching.cpp
+++ b/test/tests/row_wise_fetching.cpp
@@ -29,31 +29,31 @@ static void TestRowWiseExampleTable(HSTMT &hstmt) {
 	// NumRowsFetched.
 
 	SQLULEN row_bind_type = sizeof(t_order_info);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
 	                  reinterpret_cast<SQLPOINTER>(row_bind_type), 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_ARRAY_SIZE)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_ARRAY_SIZE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_ARRAY_SIZE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_ARRAY_SIZE,
 	                  reinterpret_cast<SQLPOINTER>(ROW_ARRAY_SIZE), 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_STATUS_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_STATUS_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_STATUS_PTR,
 	                  row_array_status, 0);
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
 	                  &rows_fetched, 0);
 
 	// Bind elements of the first structure in the array to the OrderID,
 	// SalesPerson, and Status columns.
-	EXECUTE_AND_CHECK("SQLBindCol (OrderID)", SQLBindCol, hstmt, 1, SQL_C_ULONG, &order_info[0].order_id, 0,
+	EXECUTE_AND_CHECK("SQLBindCol (OrderID)", hstmt, SQLBindCol, hstmt, 1, SQL_C_ULONG, &order_info[0].order_id, 0,
 	                  &order_info[0].order_id_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (SalesPerson)", SQLBindCol, hstmt, 2, SQL_C_CHAR, order_info[0].sales_person,
+	EXECUTE_AND_CHECK("SQLBindCol (SalesPerson)", hstmt, SQLBindCol, hstmt, 2, SQL_C_CHAR, order_info[0].sales_person,
 	                  sizeof(order_info[0].sales_person), &order_info[0].sales_person_len_or_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (Status)", SQLBindCol, hstmt, 3, SQL_C_CHAR, order_info[0].status,
+	EXECUTE_AND_CHECK("SQLBindCol (Status)", hstmt, SQLBindCol, hstmt, 3, SQL_C_CHAR, order_info[0].status,
 	                  sizeof(order_info[0].status), &order_info[0].status_len_or_ind);
 
 	// Execute a statement to retrieve rows from the Orders table.
-	EXECUTE_AND_CHECK("SQLExecDirect", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT i AS OrderID, i::VARCHAR || 'SalesPerson' AS SalesPerson, i::VARCHAR || "
 	                                   "'Status' AS Status FROM range(10) t(i)"),
 	                  SQL_NTS);
 
-	EXECUTE_AND_CHECK("SQLFetchScroll", SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
+	EXECUTE_AND_CHECK("SQLFetchScroll", hstmt, SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
 	REQUIRE(rows_fetched == ROW_ARRAY_SIZE);
 	for (int i = 0; i < rows_fetched; i++) {
 		if (row_array_status[i] == SQL_ROW_SUCCESS || row_array_status[i] == SQL_ROW_SUCCESS_WITH_INFO) {
@@ -66,7 +66,7 @@ static void TestRowWiseExampleTable(HSTMT &hstmt) {
 		}
 	}
 
-	EXECUTE_AND_CHECK("SQLCloseCursor", SQLCloseCursor, hstmt);
+	EXECUTE_AND_CHECK("SQLCloseCursor", hstmt, SQLCloseCursor, hstmt);
 }
 
 typedef struct s_many_sql_types {
@@ -96,43 +96,43 @@ void TestManySQLTypes(HSTMT &hstmt) {
 	// SQLSetStmtAttr is used to set attributes that govern the behavior of a statement.
 
 	// Specify the size of the structure with the SQL_ATTR_ROW_BIND_TYPE
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
 	                  reinterpret_cast<SQLPOINTER>(row_size), 0);
 	// Specify the number of rows to be fetched with the SQL_ATTR_ROW_ARRAY_SIZE
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_ARRAY_SIZE)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_ARRAY_SIZE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_ARRAY_SIZE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_ARRAY_SIZE,
 	                  reinterpret_cast<SQLPOINTER>(ROW_ARRAY_SIZE), 0);
 	// Specify the address of the array of row status pointers with the SQL_ATTR_ROW_STATUS_PTR
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_STATUS_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_STATUS_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_STATUS_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_STATUS_PTR,
 	                  row_array_status, 0);
 	// Specify the address of the variable that will receive the number of rows fetched with the
 	// SQL_ATTR_ROWS_FETCHED_PTR
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROWS_FETCHED_PTR)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROWS_FETCHED_PTR,
 	                  &rows_fetched, 0);
 
 	// Bind elements of the first structure to the array
-	EXECUTE_AND_CHECK("SQLBindCol (b)", SQLBindCol, hstmt, 1, SQL_C_CHAR, many_sql_types[0].b,
+	EXECUTE_AND_CHECK("SQLBindCol (b)", hstmt, SQLBindCol, hstmt, 1, SQL_C_CHAR, many_sql_types[0].b,
 	                  sizeof(many_sql_types[0].b), &many_sql_types[0].b_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (u_i)", SQLBindCol, hstmt, 2, SQL_C_ULONG, &many_sql_types[0].u_i,
+	EXECUTE_AND_CHECK("SQLBindCol (u_i)", hstmt, SQLBindCol, hstmt, 2, SQL_C_ULONG, &many_sql_types[0].u_i,
 	                  sizeof(many_sql_types[0].u_i), &many_sql_types[0].u_i_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (i)", SQLBindCol, hstmt, 3, SQL_C_LONG, &many_sql_types[0].i,
+	EXECUTE_AND_CHECK("SQLBindCol (i)", hstmt, SQLBindCol, hstmt, 3, SQL_C_LONG, &many_sql_types[0].i,
 	                  sizeof(many_sql_types[0].i), &many_sql_types[0].i_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (d)", SQLBindCol, hstmt, 4, SQL_C_DOUBLE, &many_sql_types[0].d,
+	EXECUTE_AND_CHECK("SQLBindCol (d)", hstmt, SQLBindCol, hstmt, 4, SQL_C_DOUBLE, &many_sql_types[0].d,
 	                  sizeof(many_sql_types[0].d), &many_sql_types[0].d_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (n)", SQLBindCol, hstmt, 5, SQL_C_NUMERIC, &many_sql_types[0].n,
+	EXECUTE_AND_CHECK("SQLBindCol (n)", hstmt, SQLBindCol, hstmt, 5, SQL_C_NUMERIC, &many_sql_types[0].n,
 	                  sizeof(many_sql_types[0].n), &many_sql_types[0].n_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (vchar)", SQLBindCol, hstmt, 6, SQL_C_CHAR, many_sql_types[0].vchar,
+	EXECUTE_AND_CHECK("SQLBindCol (vchar)", hstmt, SQLBindCol, hstmt, 6, SQL_C_CHAR, many_sql_types[0].vchar,
 	                  sizeof(many_sql_types[0].vchar), &many_sql_types[0].vchar_len_or_ind);
-	EXECUTE_AND_CHECK("SQLBindCol (date)", SQLBindCol, hstmt, 7, SQL_C_TYPE_DATE, many_sql_types[0].date,
+	EXECUTE_AND_CHECK("SQLBindCol (date)", hstmt, SQLBindCol, hstmt, 7, SQL_C_TYPE_DATE, many_sql_types[0].date,
 	                  sizeof(many_sql_types[0].date), &many_sql_types[0].date_len_or_ind);
 
 	EXECUTE_AND_CHECK(
-	    "SQLExecDirect", SQLExecDirect, hstmt,
+	    "SQLExecDirect", hstmt, SQLExecDirect, hstmt,
 	    ConvertToSQLCHAR("SELECT i::bool::char, i::uint8, i::int8, i::double, i::numeric, i::varchar || '-Varchar',"
 	                     "('200' || i::char || '-10-1' || i::char )::date FROM range(10) t(i)"),
 	    SQL_NTS);
 
 	// Fetch the data using SQLFetchScroll which fetches the next rowset of data from the result set.
-	EXECUTE_AND_CHECK("SQLFetchScroll", SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
+	EXECUTE_AND_CHECK("SQLFetchScroll", hstmt, SQLFetchScroll, hstmt, SQL_FETCH_NEXT, 0);
 	REQUIRE(rows_fetched == ROW_ARRAY_SIZE);
 
 	for (int i = 0; i < ROW_ARRAY_SIZE; i++) {
@@ -155,7 +155,7 @@ void TestManySQLTypes(HSTMT &hstmt) {
 		REQUIRE(date->day == 10 + i);
 	}
 
-	EXECUTE_AND_CHECK("SQLCloseCursor", SQLCloseCursor, hstmt);
+	EXECUTE_AND_CHECK("SQLCloseCursor", hstmt, SQLCloseCursor, hstmt);
 }
 
 TEST_CASE("Test Row Wise Testing and SQLFetchScroll", "[odbc]") {
@@ -167,7 +167,7 @@ TEST_CASE("Test Row Wise Testing and SQLFetchScroll", "[odbc]") {
 	// Connect to the database using SQLConnect
 	CONNECT_TO_DATABASE(env, dbc);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Test taken from ODBC documentation
 	TestRowWiseExampleTable(hstmt);
@@ -175,8 +175,8 @@ TEST_CASE("Test Row Wise Testing and SQLFetchScroll", "[odbc]") {
 	TestManySQLTypes(hstmt);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/select.cpp
+++ b/test/tests/select.cpp
@@ -12,23 +12,23 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Execute a simple query
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1 UNION ALL SELECT 2)", SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1 UNION ALL SELECT 2)",  hstmt,SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT 1 UNION ALL SELECT 2"), SQL_NTS);
 
 	// Fetch the first row
-	EXECUTE_AND_CHECK("SQLFetch (SELECT 1 UNION ALL SELECT 2)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (SELECT 1 UNION ALL SELECT 2)", hstmt, SQLFetch, hstmt);
 	// Check the data
 	DATA_CHECK(hstmt, 1, "1");
 
 	// Fetch the second row
-	EXECUTE_AND_CHECK("SQLFetch (SELECT 1 UNION ALL SELECT 2)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (SELECT 1 UNION ALL SELECT 2)", hstmt, SQLFetch, hstmt);
 	// Check the data
 	DATA_CHECK(hstmt, 1, "2");
 
-	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeStmt (SQL_CLOSE)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 
 	// Create a query with 1600 columns
 	std::string query = "SELECT ";
@@ -39,11 +39,11 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		}
 	}
 
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1600 columns)", SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()),
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1600 columns)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()),
 	                  SQL_NTS);
 
 	// Fetch the first row
-	EXECUTE_AND_CHECK("SQLFetch (SELECT 1600 columns)", SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLFetch (SELECT 1600 columns)", hstmt, SQLFetch, hstmt);
 
 	// Check the data
 	for (int i = 1; i < 1600; i++) {
@@ -60,8 +60,8 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 	REQUIRE(duckdb::StringUtil::Contains(message, "Not all parameters are bound"));
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }

--- a/test/tests/select.cpp
+++ b/test/tests/select.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Execute a simple query
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1 UNION ALL SELECT 2)",  hstmt,SQLExecDirect, hstmt,
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1 UNION ALL SELECT 2)", hstmt, SQLExecDirect, hstmt,
 	                  ConvertToSQLCHAR("SELECT 1 UNION ALL SELECT 2"), SQL_NTS);
 
 	// Fetch the first row
@@ -39,8 +39,8 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		}
 	}
 
-	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1600 columns)", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR(query.c_str()),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (SELECT 1600 columns)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR(query.c_str()), SQL_NTS);
 
 	// Fetch the first row
 	EXECUTE_AND_CHECK("SQLFetch (SELECT 1600 columns)", hstmt, SQLFetch, hstmt);

--- a/test/tests/set_attr.cpp
+++ b/test/tests/set_attr.cpp
@@ -12,34 +12,34 @@ TEST_CASE("Test SQL_ATTR_ROW_BIND_TYPE and SQL_ATTR_MAX_LENGTH attributes in SQL
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Set the statement attribute SQL_ATTR_ROW_BIND_TYPE
 	uint64_t row_len = 256;
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
 	                  ConvertToSQLPOINTER(row_len), SQL_IS_INTEGER);
 
 	// Check the statement attribute SQL_ATTR_ROW_BIND_TYPE
 	SQLULEN buf;
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", SQLGetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE, &buf,
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE, &buf,
 	                  sizeof(buf), nullptr);
 	REQUIRE(row_len == buf);
 
 	// Check that SQL_ATTR_MAX_LENGTH client attr cant be set and is preserved
 	SQLULEN max_len_buf = 1;
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
 	                  sizeof(max_len_buf), nullptr);
 	REQUIRE(0 == max_len_buf);
 	SQLULEN max_len = 42;
-	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_MAX_LENGTH)", SQLSetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH,
+	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH,
 	                  ConvertToSQLPOINTER(max_len), SQL_IS_INTEGER);
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
 	                  sizeof(max_len_buf), nullptr);
 	REQUIRE(42 == max_len_buf);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -51,18 +51,18 @@ TEST_CASE("Test MS Access attribute in SQLSetConnectAttr", "[odbc]") {
 	SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_ENV, nullptr, &env);
 	REQUIRE(ret == SQL_SUCCESS);
 
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	// Check this vendor-specific attribute can be set before the connection is open
-	EXECUTE_AND_CHECK("SQLSetConnectAttr (30002)", SQLSetConnectAttr, dbc, 30002, ConvertToSQLPOINTER(SQL_TRUE),
+	EXECUTE_AND_CHECK("SQLSetConnectAttr (30002)", nullptr, SQLSetConnectAttr, dbc, 30002, ConvertToSQLPOINTER(SQL_TRUE),
 	                  SQL_IS_INTEGER);
 
-	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
 
-	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
 }
 
 TEST_CASE("Test SQL_ATTR_ACCESS_MODE and SQL_ATTR_METADATA_ID attribute in SQLSetConnectAttr", "[odbc]") {
@@ -75,34 +75,34 @@ TEST_CASE("Test SQL_ATTR_ACCESS_MODE and SQL_ATTR_METADATA_ID attribute in SQLSe
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Set the Connect attribute SQL_ATTR_ACCESS_MODE to SQL_MODE_READ_ONLY
-	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_ACCESS_MODE)", SQLSetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
+	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLSetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
 	                  ConvertToSQLPOINTER(SQL_MODE_READ_ONLY), SQL_IS_INTEGER);
 
 	// Check the Connect attribute SQL_ATTR_ACCESS_MODE
 	SQLUINTEGER buf;
-	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
+	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
 	                  sizeof(buf), nullptr);
 	REQUIRE(SQL_MODE_READ_ONLY == buf);
 
 	// Set the Connect attribute SQL_ATTR_ACCESS_MODE to SQL_MODE_READ_WRITE
-	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_ACCESS_MODE)", SQLSetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
+	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLSetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
 	                  (SQLPOINTER)SQL_MODE_READ_WRITE, SQL_IS_INTEGER);
 
 	// Check the Connect attribute SQL_ATTR_ACCESS_MODE
-	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
+	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
 	                  sizeof(buf), nullptr);
 	REQUIRE(SQL_MODE_READ_WRITE == buf);
 
 	// Set the Connect attribute SQL_ATTR_METADATA_ID to SQL_TRUE
-	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_METADATA_ID)", SQLSetConnectAttr, dbc, SQL_ATTR_METADATA_ID,
+	EXECUTE_AND_CHECK("SQLSetConnectAttr (SQL_ATTR_METADATA_ID)", hstmt, SQLSetConnectAttr, dbc, SQL_ATTR_METADATA_ID,
 	                  ConvertToSQLPOINTER(SQL_TRUE), SQL_IS_INTEGER);
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
@@ -110,32 +110,32 @@ TEST_CASE("Test SQL_ATTR_ACCESS_MODE and SQL_ATTR_METADATA_ID attribute in SQLSe
 TEST_CASE("Test SQLSetEnvAttr and SQLGetEnvAttr") {
 	SQLHANDLE env;
 
-	EXECUTE_AND_CHECK("SQLAllocHandle (ENV)", SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLAllocHandle (ENV)", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
 
 	// Set the env attribute SQL_ATTR_ODBC_VERSION to SQL_OV_ODBC3
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 	SQLINTEGER odbc_version;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_ODBC_VERSION)", SQLGetEnvAttr, env, SQL_ATTR_ODBC_VERSION, &odbc_version,
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_ODBC_VERSION)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_ODBC_VERSION, &odbc_version,
 	                  sizeof(odbc_version), nullptr);
 	REQUIRE(odbc_version == SQL_OV_ODBC3);
 
 	// Set the env attribute SQL_ATTR_OUTPUT_NTS to SQL_TRUE
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_OUTPUT_NTS)", SQLSetEnvAttr, env, SQL_ATTR_OUTPUT_NTS,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_OUTPUT_NTS)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_OUTPUT_NTS,
 	                  ConvertToSQLPOINTER(SQL_TRUE), 0);
 	SQLINTEGER output_nts;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_OUTPUT_NTS)", SQLGetEnvAttr, env, SQL_ATTR_OUTPUT_NTS, &output_nts,
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_OUTPUT_NTS)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_OUTPUT_NTS, &output_nts,
 	                  sizeof(output_nts), nullptr);
 	REQUIRE(output_nts == SQL_TRUE);
 
 	// Set the env attribute SQL_ATTR_CONNECTION_POOLING to SQL_CP_ONE_PER_DRIVER
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", SQLSetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
 	                  ConvertToSQLPOINTER(SQL_CP_ONE_PER_DRIVER), 0);
 	SQLUINTEGER connection_pooling;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", SQLGetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
 	                  &connection_pooling, sizeof(connection_pooling), nullptr);
 	REQUIRE(connection_pooling == SQL_CP_ONE_PER_DRIVER);
 
 	// Free the env handle
-	EXECUTE_AND_CHECK("SQLFreeHandle (ENV)", SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle (ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
 }

--- a/test/tests/set_attr.cpp
+++ b/test/tests/set_attr.cpp
@@ -21,20 +21,20 @@ TEST_CASE("Test SQL_ATTR_ROW_BIND_TYPE and SQL_ATTR_MAX_LENGTH attributes in SQL
 
 	// Check the statement attribute SQL_ATTR_ROW_BIND_TYPE
 	SQLULEN buf;
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE, &buf,
-	                  sizeof(buf), nullptr);
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_ROW_BIND_TYPE)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_ROW_BIND_TYPE,
+	                  &buf, sizeof(buf), nullptr);
 	REQUIRE(row_len == buf);
 
 	// Check that SQL_ATTR_MAX_LENGTH client attr cant be set and is preserved
 	SQLULEN max_len_buf = 1;
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
-	                  sizeof(max_len_buf), nullptr);
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH,
+	                  &max_len_buf, sizeof(max_len_buf), nullptr);
 	REQUIRE(0 == max_len_buf);
 	SQLULEN max_len = 42;
 	EXECUTE_AND_CHECK("SQLSetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLSetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH,
 	                  ConvertToSQLPOINTER(max_len), SQL_IS_INTEGER);
-	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH, &max_len_buf,
-	                  sizeof(max_len_buf), nullptr);
+	EXECUTE_AND_CHECK("SQLGetStmtAttr (SQL_ATTR_MAX_LENGTH)", hstmt, SQLGetStmtAttr, hstmt, SQL_ATTR_MAX_LENGTH,
+	                  &max_len_buf, sizeof(max_len_buf), nullptr);
 	REQUIRE(42 == max_len_buf);
 
 	// Free the statement handle
@@ -57,8 +57,8 @@ TEST_CASE("Test MS Access attribute in SQLSetConnectAttr", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
 
 	// Check this vendor-specific attribute can be set before the connection is open
-	EXECUTE_AND_CHECK("SQLSetConnectAttr (30002)", nullptr, SQLSetConnectAttr, dbc, 30002, ConvertToSQLPOINTER(SQL_TRUE),
-	                  SQL_IS_INTEGER);
+	EXECUTE_AND_CHECK("SQLSetConnectAttr (30002)", nullptr, SQLSetConnectAttr, dbc, 30002,
+	                  ConvertToSQLPOINTER(SQL_TRUE), SQL_IS_INTEGER);
 
 	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
 
@@ -83,8 +83,8 @@ TEST_CASE("Test SQL_ATTR_ACCESS_MODE and SQL_ATTR_METADATA_ID attribute in SQLSe
 
 	// Check the Connect attribute SQL_ATTR_ACCESS_MODE
 	SQLUINTEGER buf;
-	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
-	                  sizeof(buf), nullptr);
+	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
+	                  &buf, sizeof(buf), nullptr);
 	REQUIRE(SQL_MODE_READ_ONLY == buf);
 
 	// Set the Connect attribute SQL_ATTR_ACCESS_MODE to SQL_MODE_READ_WRITE
@@ -92,8 +92,8 @@ TEST_CASE("Test SQL_ATTR_ACCESS_MODE and SQL_ATTR_METADATA_ID attribute in SQLSe
 	                  (SQLPOINTER)SQL_MODE_READ_WRITE, SQL_IS_INTEGER);
 
 	// Check the Connect attribute SQL_ATTR_ACCESS_MODE
-	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE, &buf,
-	                  sizeof(buf), nullptr);
+	EXECUTE_AND_CHECK("SQLGetConnectAttr (SQL_ATTR_ACCESS_MODE)", hstmt, SQLGetConnectAttr, dbc, SQL_ATTR_ACCESS_MODE,
+	                  &buf, sizeof(buf), nullptr);
 	REQUIRE(SQL_MODE_READ_WRITE == buf);
 
 	// Set the Connect attribute SQL_ATTR_METADATA_ID to SQL_TRUE
@@ -116,24 +116,24 @@ TEST_CASE("Test SQLSetEnvAttr and SQLGetEnvAttr") {
 	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
 	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
 	SQLINTEGER odbc_version;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_ODBC_VERSION)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_ODBC_VERSION, &odbc_version,
-	                  sizeof(odbc_version), nullptr);
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_ODBC_VERSION)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  &odbc_version, sizeof(odbc_version), nullptr);
 	REQUIRE(odbc_version == SQL_OV_ODBC3);
 
 	// Set the env attribute SQL_ATTR_OUTPUT_NTS to SQL_TRUE
 	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_OUTPUT_NTS)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_OUTPUT_NTS,
 	                  ConvertToSQLPOINTER(SQL_TRUE), 0);
 	SQLINTEGER output_nts;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_OUTPUT_NTS)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_OUTPUT_NTS, &output_nts,
-	                  sizeof(output_nts), nullptr);
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_OUTPUT_NTS)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_OUTPUT_NTS,
+	                  &output_nts, sizeof(output_nts), nullptr);
 	REQUIRE(output_nts == SQL_TRUE);
 
 	// Set the env attribute SQL_ATTR_CONNECTION_POOLING to SQL_CP_ONE_PER_DRIVER
-	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
-	                  ConvertToSQLPOINTER(SQL_CP_ONE_PER_DRIVER), 0);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLSetEnvAttr, env,
+	                  SQL_ATTR_CONNECTION_POOLING, ConvertToSQLPOINTER(SQL_CP_ONE_PER_DRIVER), 0);
 	SQLUINTEGER connection_pooling;
-	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLGetEnvAttr, env, SQL_ATTR_CONNECTION_POOLING,
-	                  &connection_pooling, sizeof(connection_pooling), nullptr);
+	EXECUTE_AND_CHECK("SQLGetEnvAttr (SQL_ATTR_CONNECTION_POOLING)", nullptr, SQLGetEnvAttr, env,
+	                  SQL_ATTR_CONNECTION_POOLING, &connection_pooling, sizeof(connection_pooling), nullptr);
 	REQUIRE(connection_pooling == SQL_CP_ONE_PER_DRIVER);
 
 	// Free the env handle

--- a/test/tests/test_stubs.cpp
+++ b/test/tests/test_stubs.cpp
@@ -16,7 +16,8 @@ TEST_CASE("Test SQLSpecialColumns and SQLStatistics stubs", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	{ // Check SQLSpecialColumns
-		EXECUTE_AND_CHECK("SQLSpecialColumns", hstmt, SQLSpecialColumns, hstmt, 0, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
+		EXECUTE_AND_CHECK("SQLSpecialColumns", hstmt, SQLSpecialColumns, hstmt, 0, nullptr, 0, nullptr, 0, nullptr, 0,
+		                  0, 0);
 
 		// Check columns
 		SQLSMALLINT col_count;

--- a/test/tests/test_stubs.cpp
+++ b/test/tests/test_stubs.cpp
@@ -13,14 +13,14 @@ TEST_CASE("Test SQLSpecialColumns and SQLStatistics stubs", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 
 	// Allocate a statement handle
-	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	{ // Check SQLSpecialColumns
-		EXECUTE_AND_CHECK("SQLSpecialColumns", SQLSpecialColumns, hstmt, 0, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
+		EXECUTE_AND_CHECK("SQLSpecialColumns", hstmt, SQLSpecialColumns, hstmt, 0, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
 
 		// Check columns
 		SQLSMALLINT col_count;
-		EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+		EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 		REQUIRE(col_count == 8);
 
 		// Check that the result set is empty
@@ -28,10 +28,10 @@ TEST_CASE("Test SQLSpecialColumns and SQLStatistics stubs", "[odbc]") {
 		REQUIRE(ret == SQL_NO_DATA);
 	}
 	{ // Check SQLStatistics
-		EXECUTE_AND_CHECK("SQLStatistics", SQLStatistics, hstmt, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
+		EXECUTE_AND_CHECK("SQLStatistics", hstmt, SQLStatistics, hstmt, nullptr, 0, nullptr, 0, nullptr, 0, 0, 0);
 		// Check columns
 		SQLSMALLINT col_count;
-		EXECUTE_AND_CHECK("SQLNumResultCols", SQLNumResultCols, hstmt, &col_count);
+		EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &col_count);
 		REQUIRE(col_count == 13);
 
 		// Check that the result set is empty
@@ -40,8 +40,8 @@ TEST_CASE("Test SQLSpecialColumns and SQLStatistics stubs", "[odbc]") {
 	}
 
 	// Free the statement handle
-	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", SQLFreeStmt, hstmt, SQL_CLOSE);
-	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
 
 	// Disconnect from the database
 	DISCONNECT_FROM_DATABASE(env, dbc);


### PR DESCRIPTION
Adds an extra argument to ODBC_CHECK so that the diagnostics are printed when a test fails. This should make it easier to debug in the future.