### PR TITLE
Use custom token to push vendoring changes

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -9,12 +9,6 @@ on:
             required: false
   workflow_call:
   repository_dispatch:
-  workflow_run:
-    workflows:
-      - "Vendor"
-    types:
-      - completed
-
 
 env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This change effectively reverts #97 and #98 to use the custom GH token `PAT_TOKEN` that now should be present in the ODBC repo. As a result `push` events dispatched from `Vendor.yml` should successfully trigger `ODBC.yml` runs now.