### PR TITLE
Use 4-part version numbers for releases

### DIFF
--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -6,7 +6,7 @@ on:
         type: string
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   staged_upload:


### PR DESCRIPTION
From time to time it may be necessary to make an updated release keeping the engine version exactly the same as before and only updating the ODBC part. It is proposed to use 4-part version number like `v1.2.2.1` having the last number specific for ODBC-only updates.

Note: to have this change applicable to `1.2.2.x` releases we need to add it to the `1.2` branch too.