### PR TITLE
Use 4-part version numbers for 1.2 branch

### DIFF
--- a/.github/workflows/OnTag.yml
+++ b/.github/workflows/OnTag.yml
@@ -6,7 +6,7 @@ on:
         type: string
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   staged_upload:


### PR DESCRIPTION
This change brings in the #105 PR to the 1.2 branch to allow to do `v1.2.2.1` release.