### PR TITLE
Update Ubuntu image used for clang-format runs

### DIFF
--- a/.github/workflows/CodeQuality.yml
+++ b/.github/workflows/CodeQuality.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   format-check:
     name: Format Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       CC: gcc-10
@@ -46,7 +46,10 @@ jobs:
 
       - name: Install
         shell: bash
-        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build clang-format-11 && sudo pip3 install cmake-format black
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq ninja-build clang-format-11
+          sudo pip3 install cmake-format black clang_format==11.0.1
 
       - name: Format Check
         shell: bash

--- a/test/tests/extension.cpp
+++ b/test/tests/extension.cpp
@@ -49,8 +49,7 @@ TEST_CASE("Log DuckDB Version", "[odbc]") {
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 
 	// Get the version of DuckDB
-	EXECUTE_AND_CHECK("PRAGMA version", SQLExecDirect, hstmt, ConvertToSQLCHAR("PRAGMA version"),
-	                  SQL_NTS);
+	EXECUTE_AND_CHECK("PRAGMA version", SQLExecDirect, hstmt, ConvertToSQLCHAR("PRAGMA version"), SQL_NTS);
 
 	// Fetch the results
 	EXECUTE_AND_CHECK("SQLFetch", SQLFetch, hstmt);


### PR DESCRIPTION
ODBC repo uses `clang-format-11` and `ubuntu-20.04` image to run format checks. Ubuntu 20.04 is no longer supported on GitHub hosted runners:

https://github.com/actions/runner-images/issues/11101

As `ubuntu-latest` image does not include `clang-format-11` anymore, the proposal is to move the image to `ubuntu-22.04` and then later update `clang-format` to a newer version and move the image to `ubuntu-latest`.