### PR TITLE
Fix SQLColumns output for decimal columns

### DIFF
--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -80,12 +80,12 @@ string OdbcUtils::ParseStringFilter(const string &filter_name, const string &fil
 string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const string &schema_filter,
                                         const string &table_filter, const string &column_filter) {
 	string sql_duckdb_columns = R"(
-        SELECT * EXCLUDE mapping
+        SELECT * EXCLUDE (mapping, data_type_no_typmod)
         FROM (
-            SELECT NULL "TABLE_CAT",
-            SCHEMA_NAME "TABLE_SCHEM",
-            TABLE_NAME "TABLE_NAME",
-            COLUMN_NAME "COLUMN_NAME",
+            SELECT NULL::VARCHAR AS "TABLE_CAT",
+            SCHEMA_NAME AS "TABLE_SCHEM",
+            TABLE_NAME AS "TABLE_NAME",
+            COLUMN_NAME AS "COLUMN_NAME",
             MAP {
                 'BOOLEAN': 1, -- SQL_CHAR
                 'TINYINT': -6, -- SQL_TINYINT
@@ -105,15 +105,19 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
                 'VARCHAR': 12, -- SQL_VARCHAR
                 'BLOB': -3, -- SQL_VARBINARY
                 'INTERVAL': 10, -- SQL_INTERVAL
-                'DECIMAL': 8, -- SQL_DOUBLE
+                'DECIMAL': 2, -- SQL_NUMERIC
                 'BIT': -7, -- SQL_BIT
                 'LIST': 12 -- SQL_VARCHAR
             } AS mapping,
+            STRING_SPLIT(data_type, '(')[1] AS data_type_no_typmod,
             CASE
-                WHEN mapping[data_type] IS NOT NULL THEN mapping[data_type]::BIGINT
-                ELSE data_type_id
+                WHEN mapping[data_type_no_typmod] IS NOT NULL THEN mapping[data_type_no_typmod]::SMALLINT
+                ELSE data_type_id::SMALLINT
             END AS "DATA_TYPE",
-            data_type "TYPE_NAME",
+            CASE
+                WHEN data_type_no_typmod = 'DECIMAL' THEN 'NUMERIC'
+                ELSE data_type_no_typmod
+            END AS "TYPE_NAME",
             CASE
                 WHEN data_type='DATE' THEN 12
                 WHEN data_type='TIME' THEN 15
@@ -141,28 +145,29 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
                 WHEN data_type LIKE '%INTEGER' THEN 4
                 WHEN data_type LIKE '%BIGINT' THEN 8
                 WHEN data_type='HUGEINT' THEN 16
+                WHEN data_type like 'DECIMAL%' THEN 16
                 WHEN data_type='FLOAT' THEN 4
                 WHEN data_type='DOUBLE' THEN 8
                 ELSE NULL
             END AS "BUFFER_LENGTH",
-            numeric_scale "DECIMAL_DIGITS",
-            numeric_precision_radix "NUM_PREC_RADIX",
+            numeric_scale::SMALLINT AS "DECIMAL_DIGITS",
+            numeric_precision_radix::SMALLINT "NUM_PREC_RADIX",
             CASE is_nullable
-                WHEN FALSE THEN 0
-                WHEN TRUE THEN 1
-                ELSE 2
+                WHEN FALSE THEN 0::SMALLINT
+                WHEN TRUE THEN 1::SMALLINT
+                ELSE 2::SMALLINT
             END AS "NULLABLE",
-            NULL "REMARKS",
-            column_default "COLUMN_DEF",
+            '' AS "REMARKS",
+            column_default AS "COLUMN_DEF",
             CASE
-                WHEN mapping[data_type] IS NOT NULL THEN mapping[data_type]::BIGINT
-                ELSE data_type_id
+                WHEN mapping[data_type_no_typmod] IS NOT NULL THEN mapping[data_type_no_typmod]::SMALLINT
+                ELSE data_type_id::SMALLINT
             END AS "SQL_DATA_TYPE",
             CASE
                 WHEN data_type='DATE'
                      OR data_type='TIME'
-                     OR data_type LIKE 'TIMESTAMP%' THEN data_type_id
-                ELSE NULL
+                     OR data_type LIKE 'TIMESTAMP%' THEN data_type_id::SMALLINT
+                ELSE NULL::SMALLINT
             END AS "SQL_DATETIME_SUB",
             CASE
                 WHEN data_type='%CHAR'

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -191,6 +191,9 @@ void InitializeDatabase(HSTMT &hstmt) {
 	EXEC_SQL(hstmt, "INSERT INTO bytea_table VALUES (4, 'foo');");
 	EXEC_SQL(hstmt, "INSERT INTO bytea_table VALUES (5, 'barf');");
 
+	EXEC_SQL(hstmt, "DROP TABLE IF EXISTS decimal_table;");
+	EXEC_SQL(hstmt, "CREATE TABLE decimal_table (col1 DECIMAL(15,2));");
+
 	EXEC_SQL(hstmt, "DROP TABLE IF EXISTS interval_table;");
 	EXEC_SQL(hstmt, "CREATE TABLE interval_table(id integer, iv interval, d varchar(100));");
 	EXEC_SQL(hstmt, "INSERT INTO interval_table VALUES (1, '1 day', 'one day');");

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -159,12 +159,15 @@ static void TestSQLTables(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_ma
 			DATA_CHECK(hstmt, 3, "bytea_table");
 			break;
 		case 3:
-			DATA_CHECK(hstmt, 3, "interval_table");
+			DATA_CHECK(hstmt, 3, "decimal_table");
 			break;
 		case 4:
-			DATA_CHECK(hstmt, 3, "lo_test_table");
+			DATA_CHECK(hstmt, 3, "interval_table");
 			break;
 		case 5:
+			DATA_CHECK(hstmt, 3, "lo_test_table");
+			break;
+		case 6:
 			DATA_CHECK(hstmt, 3, "test_table_1");
 		}
 
@@ -208,9 +211,9 @@ static void TestSQLTablesSchema(HSTMT &hstmt) {
 	EXECUTE_AND_CHECK("SQLTables", SQLTables, hstmt, nullptr, 0, ConvertToSQLCHAR(""), SQL_NTS, ConvertToSQLCHAR("%"),
 	                  SQL_NTS, ConvertToSQLCHAR("TABLE"), SQL_NTS);
 
-	std::vector<std::array<std::string, 4>> expected_data = {{"test_table_2", "ducks"}, {"bool_table", "main"},
-	                                                         {"bytea_table", "main"},   {"interval_table", "main"},
-	                                                         {"lo_test_table", "main"}, {"test_table_1", "main"}};
+	std::vector<std::array<std::string, 4>> expected_data = {
+	    {"test_table_2", "ducks"},  {"bool_table", "main"},    {"bytea_table", "main"}, {"decimal_table", "main"},
+	    {"interval_table", "main"}, {"lo_test_table", "main"}, {"test_table_1", "main"}};
 
 	for (int i = 0; i < expected_data.size(); i++) {
 		SQLRETURN ret = SQLFetch(hstmt);
@@ -250,11 +253,11 @@ static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_m
 
 	// Create a map of column types and a vector of expected metadata
 	std::vector<MetadataData> expected_metadata = {
-	    {"TABLE_CAT", SQL_INTEGER},         {"TABLE_SCHEM", SQL_VARCHAR},      {"TABLE_NAME", SQL_VARCHAR},
-	    {"COLUMN_NAME", SQL_VARCHAR},       {"DATA_TYPE", SQL_BIGINT},         {"TYPE_NAME", SQL_VARCHAR},
-	    {"COLUMN_SIZE", SQL_INTEGER},       {"BUFFER_LENGTH", SQL_INTEGER},    {"DECIMAL_DIGITS", SQL_INTEGER},
-	    {"NUM_PREC_RADIX", SQL_INTEGER},    {"NULLABLE", SQL_INTEGER},         {"REMARKS", SQL_INTEGER},
-	    {"COLUMN_DEF", SQL_VARCHAR},        {"SQL_DATA_TYPE", SQL_BIGINT},     {"SQL_DATETIME_SUB", SQL_BIGINT},
+	    {"TABLE_CAT", SQL_VARCHAR},         {"TABLE_SCHEM", SQL_VARCHAR},      {"TABLE_NAME", SQL_VARCHAR},
+	    {"COLUMN_NAME", SQL_VARCHAR},       {"DATA_TYPE", SQL_SMALLINT},       {"TYPE_NAME", SQL_VARCHAR},
+	    {"COLUMN_SIZE", SQL_INTEGER},       {"BUFFER_LENGTH", SQL_INTEGER},    {"DECIMAL_DIGITS", SQL_SMALLINT},
+	    {"NUM_PREC_RADIX", SQL_SMALLINT},   {"NULLABLE", SQL_SMALLINT},        {"REMARKS", SQL_VARCHAR},
+	    {"COLUMN_DEF", SQL_VARCHAR},        {"SQL_DATA_TYPE", SQL_SMALLINT},   {"SQL_DATETIME_SUB", SQL_SMALLINT},
 	    {"CHAR_OCTET_LENGTH", SQL_INTEGER}, {"ORDINAL_POSITION", SQL_INTEGER}, {"IS_NULLABLE", SQL_VARCHAR}};
 
 	for (int i = 0; i < col_count; i++) {
@@ -264,13 +267,22 @@ static void TestSQLColumns(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_m
 	}
 
 	std::vector<std::array<std::string, 4>> expected_data = {
-	    {"bool_table", "id", "4", "INTEGER"},       {"bool_table", "t", "12", "VARCHAR"},
-	    {"bool_table", "b", "1", "BOOLEAN"},        {"bytea_table", "id", "4", "INTEGER"},
-	    {"bytea_table", "t", "-3", "BLOB"},         {"interval_table", "id", "4", "INTEGER"},
-	    {"interval_table", "iv", "10", "INTERVAL"}, {"interval_table", "d", "12", "VARCHAR"},
-	    {"lo_test_table", "id", "4", "INTEGER"},    {"lo_test_table", "large_data", "-3", "BLOB"},
-	    {"test_table_1", "id", "4", "INTEGER"},     {"test_table_1", "t", "12", "VARCHAR"},
-	    {"test_view", "id", "4", "INTEGER"},        {"test_view", "t", "12", "VARCHAR"}};
+	    {"bool_table", "id", "4", "INTEGER"},
+	    {"bool_table", "t", "12", "VARCHAR"},
+	    {"bool_table", "b", "1", "BOOLEAN"},
+	    {"bytea_table", "id", "4", "INTEGER"},
+	    {"bytea_table", "t", "-3", "BLOB"},
+	    {"decimal_table", "col1", "2", "NUMERIC"},
+	    {"interval_table", "id", "4", "INTEGER"},
+	    {"interval_table", "iv", "10", "INTERVAL"},
+	    {"interval_table", "d", "12", "VARCHAR"},
+	    {"lo_test_table", "id", "4", "INTEGER"},
+	    {"lo_test_table", "large_data", "-3", "BLOB"},
+	    {"test_table_1", "id", "4", "INTEGER"},
+	    {"test_table_1", "t", "12", "VARCHAR"},
+	    {"test_view", "id", "4", "INTEGER"},
+	    {"test_view", "t", "12", "VARCHAR"},
+	};
 
 	for (int i = 0; i < expected_data.size(); i++) {
 		SQLRETURN ret = SQLFetch(hstmt);


### PR DESCRIPTION
`SQLColumns` was returning decimal column type as `SQL_DOUBLE` and also was including type modifiers into the value in the `TYPE_NAME` column.

This confused PowerBI client which interpreted decimal columns as binary columns and was unable to use them with parameters binding, and this was breaking the query folding.

The patch removes type modifiers from the `TYPE_NAME` column and changes the output type to `SQL_NUMERIC`. While `SQL_DECIMAL` may be more appropriate for decimal columns, it appeared that `SQL_DECIMAL` causes type conversion issues on PowerBI side, see details in the issue linked in #77.

It also changes column types of the `SQLColumns` output to match the types required by ODBC spec.

Testing: existing test is extended to cover decimal columns.

Fixes: #77