### PR TITLE
Fix the crash on allowed_paths config option

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   tests/numeric.cpp
   tests/quotes.cpp
   tests/result_conversion.cpp
+  tests/test_allowed_paths.cpp
   tests/test_stubs.cpp
   tests/test_timestamp.cpp
   tests/test_widechar_conv.cpp

--- a/test/tests/catalog_functions.cpp
+++ b/test/tests/catalog_functions.cpp
@@ -31,7 +31,7 @@ void TestGetTypeInfo(HSTMT &hstmt, std::map<SQLSMALLINT, SQLULEN> &types_map) {
 
 	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 
-	std::string max_col_size = std::to_string((std::numeric_limits<SQLINTEGER>::max)());
+	std::string max_col_size = std::to_string(std::numeric_limits<SQLINTEGER>::max());
 
 	std::vector<std::pair<MetadataData, std::string>> expected_data = {{{"TYPE_NAME", SQL_VARCHAR}, "VARCHAR"},
 	                                                                   {{"DATA_TYPE", SQL_SMALLINT}, "12"},

--- a/test/tests/col_attribute/char_query.cpp
+++ b/test/tests/col_attribute/char_query.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test SQLColAttribute for a query that returns a char", "[odbc]") {
 	expected_chars[SQL_DESC_COUNT] = ExpectedResult(2);
 	expected_chars[SQL_DESC_DISPLAY_SIZE] = ExpectedResult(256);
 	expected_chars[SQL_DESC_FIXED_PREC_SCALE] = ExpectedResult(SQL_FALSE);
-	expected_chars[SQL_DESC_LENGTH] = ExpectedResult((std::numeric_limits<SQLINTEGER>::max)());
+	expected_chars[SQL_DESC_LENGTH] = ExpectedResult(std::numeric_limits<SQLINTEGER>::max());
 	expected_chars[SQL_DESC_LITERAL_PREFIX] = ExpectedResult("''''");
 	expected_chars[SQL_DESC_LITERAL_SUFFIX] = ExpectedResult("''''");
 	expected_chars[SQL_DESC_LOCAL_TYPE_NAME] = ExpectedResult("");

--- a/test/tests/col_attribute/uuid_query.cpp
+++ b/test/tests/col_attribute/uuid_query.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test SQLColAttribute for a query that returns a uuid", "[odbc]") {
 	expected_chars[SQL_DESC_COUNT] = ExpectedResult(2);
 	expected_chars[SQL_DESC_DISPLAY_SIZE] = ExpectedResult(0);
 	expected_chars[SQL_DESC_FIXED_PREC_SCALE] = ExpectedResult(SQL_FALSE);
-	expected_chars[SQL_DESC_LENGTH] = ExpectedResult((std::numeric_limits<SQLINTEGER>::max)());
+	expected_chars[SQL_DESC_LENGTH] = ExpectedResult(std::numeric_limits<SQLINTEGER>::max());
 	expected_chars[SQL_DESC_LITERAL_PREFIX] = ExpectedResult("''''");
 	expected_chars[SQL_DESC_LITERAL_SUFFIX] = ExpectedResult("''''");
 	expected_chars[SQL_DESC_LOCAL_TYPE_NAME] = ExpectedResult("");

--- a/test/tests/test_allowed_paths.cpp
+++ b/test/tests/test_allowed_paths.cpp
@@ -1,0 +1,122 @@
+#include "odbc_test_common.h"
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace odbc_test;
+
+static void check_read_file(HSTMT hstmt, const std::string &path, SQLRETURN expected_ret = SQL_SUCCESS,
+                            const std::string &expected_state = std::string(),
+                            const std::string &expected_msg = std::string()) {
+	std::string text("foo");
+
+	{ // Write the file
+		std::ofstream file(path);
+		file << text;
+	}
+
+	// Try to read the file
+	auto ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT * FROM read_text('" + path + "')"), SQL_NTS);
+
+	// Clean up promptly
+	std::remove(path.c_str());
+
+	// Check expected success or failure
+	REQUIRE(ret == expected_ret);
+
+	// Check details
+	if (expected_ret == SQL_SUCCESS) {
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+		std::vector<char> fetched_buf;
+		fetched_buf.resize(256);
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, fetched_buf.data(), fetched_buf.size(),
+		                  nullptr);
+		REQUIRE(std::string(fetched_buf.data()) == text);
+	} else {
+		std::string state, message;
+		ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
+		REQUIRE(state == expected_state);
+		REQUIRE(duckdb::StringUtil::Contains(message, expected_msg));
+	}
+}
+
+TEST_CASE("Test allowed_paths option", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// TODO: need to add generic scratch test dir support
+	auto fs = duckdb::FileSystem::CreateLocal();
+	std::string dir = fs->GetWorkingDirectory();
+	std::string file_allowed_1 = fs->JoinPath(dir, "test_allowed_paths_1.txt");
+	std::string file_allowed_2 = fs->JoinPath(dir, "test_allowed_paths_2.txt");
+	std::string file_not_allowed_1 = fs->JoinPath(dir, "test_allowed_paths_3.txt");
+
+	// Connect to the database using SQLConnect
+	DRIVER_CONNECT_TO_DATABASE(env, dbc,
+	                           "Driver={DuckDB Driver};enable_external_access=false;"
+	                           "allowed_paths=['" +
+	                               file_allowed_1 + "', '" + file_allowed_2 + "']");
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	// Check read from allowed path
+	check_read_file(hstmt, file_allowed_1);
+
+	// Check read from unallowed path
+	check_read_file(hstmt, file_not_allowed_1, SQL_ERROR, "42000", "Permission Error: Cannot access file");
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	// Disconnect from the database
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test allowed_directories option", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// TODO: need to add generic scratch test dir support
+	auto fs = duckdb::FileSystem::CreateLocal();
+	std::string dir = fs->GetWorkingDirectory();
+	std::string dir_allowed_1 = fs->JoinPath(dir, "test_allowed_paths_dir_1");
+	fs->CreateDirectory(dir_allowed_1);
+	std::string dir_allowed_2 = fs->JoinPath(dir, "test_allowed_paths_dir_2");
+	std::string dir_not_allowed_1 = fs->JoinPath(dir, "test_allowed_paths_dir_3");
+	fs->CreateDirectory(dir_not_allowed_1);
+
+	// Connect to the database using SQLConnect
+	DRIVER_CONNECT_TO_DATABASE(env, dbc,
+	                           "Driver={DuckDB Driver};enable_external_access=false;"
+	                           "allowed_directories=['" +
+	                               dir_allowed_1 + "', '" + dir_allowed_2 + "']");
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	// Check read from allowed path
+	check_read_file(hstmt, fs->JoinPath(dir_allowed_1, "foo.txt"));
+
+	// Check read from unallowed path
+	check_read_file(hstmt, fs->JoinPath(dir_not_allowed_1, "foo.txt"), SQL_ERROR, "42000",
+	                "Permission Error: Cannot access file");
+
+	// Cleanup
+	fs->RemoveDirectory(dir_allowed_1);
+	fs->RemoveDirectory(dir_not_allowed_1);
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	// Disconnect from the database
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}

--- a/test/tests/test_widechar_conv.cpp
+++ b/test/tests/test_widechar_conv.cpp
@@ -310,7 +310,7 @@ TEST_CASE("Test utf8_alloc_out_vec function", "[odbc_widechar]") {
 	std::vector<SQLCHAR> small_vec = utf8_alloc_out_vec(100);
 	REQUIRE(small_vec.size() == 300);
 	std::vector<SQLCHAR> large_vec = utf8_alloc_out_vec(30000);
-	REQUIRE(large_vec.size() == (std::numeric_limits<SQLSMALLINT>::max)());
+	REQUIRE(large_vec.size() == std::numeric_limits<SQLSMALLINT>::max());
 }
 
 // This test mimics the intended usage of widechar helper functions


### PR DESCRIPTION
Currently options `allowed_paths` and `allowed_directories` require to have an initialized FS instance attached to the DB config. Otherwise the process of checking file separators in the option value fails with `Attempted to dereference unique_ptr that is NULL`.

This is tracked in the engine in duckdb/duckdb#17128 and is likely to be fixed soon, but meanwhile it is proposed to add the fix to ODBC to not crash the host process when one of these options is set in DSN config.

Additionally the logic added to set `enable_external_access` option after all other options (otherwise path-related options are not allowed to be set) and to handle backslashes in windows paths in path-related options.

Testing: new test added that checks that files can/cannot be read when `allowed_paths` and `allowed_directories` options are used.

edit: updated description after the inclusion of additional path-related fixes