### PR TITLE
Clean up narrowing warnings

### DIFF
--- a/src/api_info.cpp
+++ b/src/api_info.cpp
@@ -62,7 +62,7 @@ SQLRETURN SQL_API SQLGetTypeInfo(SQLHSTMT statement_handle, SQLSMALLINT data_typ
 	))";
 	// clang-format on
 
-	return duckdb::ExecDirectStmt(hstmt, (SQLCHAR *)query.c_str(), query.size());
+	return duckdb::ExecDirectStmt(hstmt, (SQLCHAR *)query.c_str(), static_cast<SQLINTEGER>(query.size()));
 }
 
 /*** ApiInfo private attributes ********************************/

--- a/src/common/odbc_fetch.cpp
+++ b/src/common/odbc_fetch.cpp
@@ -359,8 +359,8 @@ SQLRETURN OdbcFetch::ColumnWise(OdbcHandleStmt *hstmt) {
 				target_len_addr += row_idx;
 			}
 
-			ret = duckdb::GetDataStmtResult(hstmt, col_idx + 1, bound_col.type, target_val_addr, bound_col.len,
-			                                target_len_addr);
+			ret = duckdb::GetDataStmtResult(hstmt, static_cast<SQLUSMALLINT>(col_idx + 1), bound_col.type,
+			                                target_val_addr, bound_col.len, target_len_addr);
 			if (!SQL_SUCCEEDED(ret)) {
 				SetRowStatus(row_idx, SQL_ROW_ERROR);
 			}
@@ -400,8 +400,8 @@ SQLRETURN OdbcFetch::RowWise(OdbcHandleStmt *hstmt) {
 			uint8_t *target_val_addr = (uint8_t *)bound_col.ptr + row_offset;
 			uint8_t *target_len_addr = (uint8_t *)bound_col.strlen_or_ind + row_offset;
 
-			ret = duckdb::GetDataStmtResult(hstmt, col_idx + 1, bound_col.type, target_val_addr, bound_col.len,
-			                                (SQLLEN *)target_len_addr);
+			ret = duckdb::GetDataStmtResult(hstmt, static_cast<SQLUSMALLINT>(col_idx + 1), bound_col.type,
+			                                target_val_addr, bound_col.len, (SQLLEN *)target_len_addr);
 			if (!SQL_SUCCEEDED(ret)) {
 				SetRowStatus(row_idx, SQL_ROW_ERROR);
 			}
@@ -458,6 +458,6 @@ SQLLEN OdbcFetch::GetRowCount() {
 
 void OdbcFetch::SetRowStatus(idx_t row_idx, SQLINTEGER status) {
 	if (hstmt_ref->row_desc->ird->header.sql_desc_array_status_ptr) {
-		hstmt_ref->row_desc->ird->header.sql_desc_array_status_ptr[row_idx] = status;
+		hstmt_ref->row_desc->ird->header.sql_desc_array_status_ptr[row_idx] = static_cast<SQLUSMALLINT>(status);
 	}
 }

--- a/src/common/odbc_interval.cpp
+++ b/src/common/odbc_interval.cpp
@@ -63,7 +63,7 @@ void OdbcInterval::SetDay(interval_t &interval, SQL_INTERVAL_STRUCT *interval_st
 	interval_struct->interval_type = SQLINTERVAL::SQL_IS_DAY;
 	// set the absolute value of days
 	interval_struct->intval.day_second.day =
-	    std::abs(interval.days + interval.months * duckdb::Interval::DAYS_PER_MONTH);
+	    static_cast<SQLUINTEGER>(std::abs(interval.days + interval.months * duckdb::Interval::DAYS_PER_MONTH));
 }
 
 void OdbcInterval::SetHour(interval_t &interval, SQL_INTERVAL_STRUCT *interval_struct) {
@@ -72,7 +72,8 @@ void OdbcInterval::SetHour(interval_t &interval, SQL_INTERVAL_STRUCT *interval_s
 	interval_struct->interval_type = SQLINTERVAL::SQL_IS_HOUR;
 
 	interval_struct->intval.day_second.hour = interval_struct->intval.day_second.day * duckdb::Interval::HOURS_PER_DAY;
-	interval_struct->intval.day_second.hour += std::abs(interval.micros) / duckdb::Interval::MICROS_PER_HOUR;
+	interval_struct->intval.day_second.hour +=
+	    static_cast<SQLUINTEGER>(std::abs(interval.micros) / duckdb::Interval::MICROS_PER_HOUR);
 	// remaning stores into the fraction
 	interval_struct->intval.day_second.fraction = std::abs(interval.micros) % duckdb::Interval::MICROS_PER_HOUR;
 }
@@ -98,7 +99,8 @@ void OdbcInterval::SetSecond(interval_t &interval, SQL_INTERVAL_STRUCT *interval
 
 	interval_struct->intval.day_second.second =
 	    interval_struct->intval.day_second.minute * duckdb::Interval::SECS_PER_MINUTE;
-	interval_struct->intval.day_second.fraction += std::abs(interval.micros) / duckdb::Interval::MICROS_PER_SEC;
+	interval_struct->intval.day_second.fraction +=
+	    static_cast<SQLUINTEGER>(std::abs(interval.micros) / duckdb::Interval::MICROS_PER_SEC);
 	// remaning stores into the fraction
 	interval_struct->intval.day_second.fraction = std::abs(interval.micros) % duckdb::Interval::MICROS_PER_SEC;
 }
@@ -107,10 +109,12 @@ void OdbcInterval::SetDayToHour(interval_t &interval, SQL_INTERVAL_STRUCT *inter
 	SetDay(interval, interval_struct);
 	interval_struct->interval_type = SQLINTERVAL::SQL_IS_DAY_TO_HOUR;
 	// set hours
-	interval_struct->intval.day_second.hour = std::abs(interval.micros) / duckdb::Interval::MICROS_PER_HOUR;
+	interval_struct->intval.day_second.hour =
+	    static_cast<SQLUINTEGER>(std::abs(interval.micros) / duckdb::Interval::MICROS_PER_HOUR);
 
 	// remaning stores into the fraction
-	interval_struct->intval.day_second.fraction = std::abs(interval.micros) % duckdb::Interval::MICROS_PER_HOUR;
+	interval_struct->intval.day_second.fraction =
+	    static_cast<SQLUINTEGER>(std::abs(interval.micros) % duckdb::Interval::MICROS_PER_HOUR);
 }
 
 void OdbcInterval::SetDayToMinute(interval_t &interval, SQL_INTERVAL_STRUCT *interval_struct) {

--- a/src/connect/connection.cpp
+++ b/src/connect/connection.cpp
@@ -570,7 +570,7 @@ SQLRETURN SQL_API SQLGetInfo(SQLHDBC connection_handle, SQLUSMALLINT info_type, 
 		if (string_length_ptr) {
 			SQLLEN len_ptr;
 			ret = SQLGetData(stmt, 1, SQL_C_CHAR, info_value_ptr, buffer_length, &len_ptr);
-			*string_length_ptr = len_ptr;
+			*string_length_ptr = static_cast<SQLSMALLINT>(len_ptr);
 		} else {
 			ret = SQLGetData(stmt, 1, SQL_C_CHAR, info_value_ptr, buffer_length, nullptr);
 		}

--- a/src/descriptor.cpp
+++ b/src/descriptor.cpp
@@ -523,7 +523,7 @@ void OdbcHandleDesc::CopyFieldByField(const OdbcHandleDesc &other) {
 duckdb::DescRecord *OdbcHandleDesc::GetDescRecord(duckdb::idx_t param_idx) {
 	if (param_idx >= records.size()) {
 		records.resize(param_idx + 1);
-		header.sql_desc_count = records.size();
+		header.sql_desc_count = static_cast<SQLSMALLINT>(records.size());
 	}
 	return &records[param_idx];
 }

--- a/src/parameter_descriptor.cpp
+++ b/src/parameter_descriptor.cpp
@@ -338,12 +338,13 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 			return SQL_ERROR;
 		}
 		if (precision <= Decimal::MAX_WIDTH_INT64) {
-			value = Value::DECIMAL(Load<int64_t>(dataptr), precision, scale);
+			value =
+			    Value::DECIMAL(Load<int64_t>(dataptr), static_cast<uint8_t>(precision), static_cast<uint8_t>(scale));
 		} else {
 			hugeint_t dec_value;
 			memcpy(&dec_value.lower, dataptr, sizeof(dec_value.lower));
 			memcpy(&dec_value.upper, dataptr + sizeof(dec_value.lower), sizeof(dec_value.upper));
-			value = Value::DECIMAL(dec_value, precision, scale);
+			value = Value::DECIMAL(dec_value, static_cast<uint8_t>(precision), static_cast<uint8_t>(scale));
 		}
 		break;
 	}

--- a/src/statement/statement.cpp
+++ b/src/statement/statement.cpp
@@ -82,7 +82,7 @@ SQLRETURN SQL_API SQLSetStmtAttr(SQLHSTMT statement_handle, SQLINTEGER attribute
 		if (value_ptr == nullptr) {
 			return SQL_ERROR;
 		}
-		hstmt->row_desc->ard->header.sql_desc_bind_type = (SQLULEN)value_ptr;
+		hstmt->row_desc->ard->header.sql_desc_bind_type = static_cast<SQLINTEGER>(reinterpret_cast<SQLLEN>(value_ptr));
 		return SQL_SUCCESS;
 	}
 	case SQL_ATTR_ROW_STATUS_PTR: {
@@ -448,7 +448,8 @@ SQLRETURN SQL_API SQLTables(SQLHSTMT statement_handle, SQLCHAR *catalog_name, SQ
 
 	string sql_tables = OdbcUtils::GetQueryDuckdbTables(schema_filter, table_filter, table_tp);
 
-	if (!SQL_SUCCEEDED(duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)sql_tables.c_str(), sql_tables.size()))) {
+	if (!SQL_SUCCEEDED(duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)sql_tables.c_str(),
+	                                          static_cast<SQLINTEGER>(sql_tables.size())))) {
 		return SQL_ERROR;
 	}
 
@@ -487,7 +488,8 @@ SQLRETURN SQL_API SQLColumns(SQLHSTMT statement_handle, SQLCHAR *catalog_name, S
 
 	string sql_columns = OdbcUtils::GetQueryDuckdbColumns(catalog_filter, schema_filter, table_filter, column_filter);
 
-	ret = duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)sql_columns.c_str(), sql_columns.size());
+	ret = duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)sql_columns.c_str(),
+	                             static_cast<SQLINTEGER>(sql_columns.size()));
 	if (!SQL_SUCCEEDED(ret)) {
 		return ret;
 	}
@@ -510,7 +512,8 @@ SELECT
 	CAST(0  AS SMALLINT) AS "PSEUDO_COLUMN"
 WHERE 1 < 0
 )#";
-	SQLRETURN ret = duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)query.c_str(), query.size());
+	SQLRETURN ret =
+	    duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)query.c_str(), static_cast<SQLINTEGER>(query.size()));
 	if (!SQL_SUCCEEDED(ret)) {
 		return ret;
 	}
@@ -537,7 +540,8 @@ SELECT
 	CAST('' AS VARCHAR ) AS "FILTER_CONDITION"
 WHERE 1 < 0
 )#";
-	SQLRETURN ret = duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)query.c_str(), query.size());
+	SQLRETURN ret =
+	    duckdb::ExecDirectStmt(statement_handle, (SQLCHAR *)query.c_str(), static_cast<SQLINTEGER>(query.size()));
 	if (!SQL_SUCCEEDED(ret)) {
 		return ret;
 	}
@@ -561,7 +565,7 @@ static SQLRETURN SetCharacterAttributePtr(duckdb::OdbcHandleStmt *hstmt, const s
                                           SQLSMALLINT *string_length_ptr) {
 	// user only wants the size of the character attribute
 	if (character_attribute_ptr == nullptr && string_length_ptr) {
-		*string_length_ptr = str.size();
+		*string_length_ptr = static_cast<SQLSMALLINT>(str.size());
 		return SQL_SUCCESS;
 	}
 	if (buffer_length <= 0) {

--- a/src/statement/statement_functions.cpp
+++ b/src/statement/statement_functions.cpp
@@ -66,7 +66,7 @@ SQLRETURN duckdb::FinalizeStmt(duckdb::OdbcHandleStmt *hstmt) {
 		                            SQLStateType::ST_42000, hstmt->dbc->GetDataSourceName()));
 	}
 
-	hstmt->param_desc->ResetParams(hstmt->stmt->named_param_map.size());
+	hstmt->param_desc->ResetParams(static_cast<SQLSMALLINT>(hstmt->stmt->named_param_map.size()));
 
 	hstmt->bound_cols.resize(hstmt->stmt->ColumnCount());
 
@@ -452,7 +452,7 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 		auto pos_dot = str_val.find('.');
 		if (pos_dot != string::npos) {
 			str_val.erase(std::remove(str_val.begin(), str_val.end(), '.'), str_val.end());
-			numeric->scale = str_val.size() - pos_dot;
+			numeric->scale = static_cast<SQLSCHAR>(str_val.size() - pos_dot);
 
 			string str_fraction = str_val.substr(pos_dot);
 			// case all digits in fraction is 0, remove them
@@ -461,9 +461,9 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			}
 			width = str_val.size();
 		}
-		numeric->precision = width;
+		numeric->precision = static_cast<SQLCHAR>(width);
 
-		string_t str_t(str_val.c_str(), width);
+		string_t str_t(str_val.c_str(), static_cast<uint32_t>(width));
 		if (numeric->precision <= Decimal::MAX_WIDTH_INT64) {
 			int64_t val_i64;
 			if (!duckdb::TryCast::Operation(str_t, val_i64)) {
@@ -971,11 +971,11 @@ SQLRETURN duckdb::BindParameterStmt(SQLHSTMT statement_handle, SQLUSMALLINT para
 
 	ipd_record->sql_desc_parameter_type = input_output_type;
 	ipd_record->sql_desc_length = column_size;
-	ipd_record->sql_desc_precision = column_size;
+	ipd_record->sql_desc_precision = static_cast<SQLSMALLINT>(column_size);
 	ipd_record->sql_desc_scale = decimal_digits;
 	if (value_type == SQL_DECIMAL || value_type == SQL_NUMERIC || value_type == SQL_FLOAT || value_type == SQL_REAL ||
 	    value_type == SQL_DOUBLE) {
-		ipd_record->sql_desc_precision = column_size;
+		ipd_record->sql_desc_precision = static_cast<SQLSMALLINT>(column_size);
 	}
 
 	if (ipd_record->SetSqlDataType(parameter_type) == SQL_ERROR ||


### PR DESCRIPTION
This change is moved out from #118 PR.

There are a few warnings about integer narrowing in the codebase. These warning produce a lot of output on Windows and make it easy to miss actually important warnings from new changes.

This change added explicit static casts for integers narrowing.

Testing: no functional changes, no new tests.