### PR TITLE
Minor fix to vendoring PRs check

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -351,7 +351,7 @@ jobs:
 
   odbc-merge-vendoring-pr:
     name: Merge vendoring PR 
-    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == 'vendoring-${{ github.ref_name }}' }}
+    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == format('vendoring-{0}', github.ref_name) }}
     needs:
       - odbc-linux-amd64
       - odbc-linux-aarch64


### PR DESCRIPTION
This change fixes the auto-close logic for vendoring PRs by properly formatting the name of the vendoring branch that is used in the job startup check.