### PR TITLE
Fix workflow job that merges vendoring PRs

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -351,7 +351,7 @@ jobs:
 
   odbc-merge-vendoring-pr:
     name: Merge vendoring PR 
-    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == format('vendoring-{0}', github.ref_name) }}
+    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == format('vendoring-{0}', github.base_ref) }}
     needs:
       - odbc-linux-amd64
       - odbc-linux-aarch64
@@ -368,8 +368,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            # echo "Merging PR number: ${{ github.event.pull_request.number }} with message: ${{ github.event.pull_request.title }}"
-            gh pr merge vendoring-${{ github.ref_name }} \
+            echo "Merging PR number: ${{ github.event.pull_request.number }} with message: ${{ github.event.pull_request.title }}"
+            gh pr merge vendoring-${{ github.base_ref }} \
              --rebase \
              --subject "${{ github.event.pull_request.title }}" \
              --body ""
@@ -378,9 +378,9 @@ jobs:
         id: update_vendoring_branch
         if: ${{ steps.merge_vendoring_pr.outcome == 'success' }}
         run: |
-            # Delete vendoring-${{ github.ref_name }} branch and re-create it for future PRs
-            git push --delete origin vendoring-${{ github.ref_name }}
+            # Delete vendoring-${{ github.base_ref }} branch and re-create it for future PRs
+            git push --delete origin vendoring-${{ github.base_ref }}
             git checkout --track origin/main
             git pull --ff-only
-            git branch vendoring-${{ github.ref_name }}
-            git push origin vendoring-${{ github.ref_name }}
+            git branch vendoring-${{ github.base_ref }}
+            git push origin vendoring-${{ github.base_ref }}

--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -51,7 +51,6 @@ jobs:
           git checkout ${{ inputs.duckdb-sha }}
 
       - name: Vendor sources
-        if: ${{ steps.checkout_engine_rev.outcome == 'success' }}
         id: vendor
         run: |
           REV=$(cd .git/duckdb && git rev-parse --short HEAD && cd ../..)
@@ -73,7 +72,6 @@ jobs:
 
       - name: Commit and push the changes
         id: commit_and_push
-        if: ${{ steps.vendor.outcome == 'success' }}
         run: |
           MSG="Update vendored DuckDB sources to ${{ steps.vendor.outputs.vendor_rev }}"
           git commit -m "${MSG}"
@@ -89,7 +87,6 @@ jobs:
 
       - name: Check PR exists
         id: check_pr_exists
-        if: ${{ steps.commit_and_push.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -105,7 +102,6 @@ jobs:
 
       - name: Prepare PR message
         id: prepare_pr_message
-        if: ${{ steps.check_pr_exists.outcome == 'success' }}
         run: |
             DATE="$(date +"%Y-%m-%d %H:%M:%S")"
             CHANGE_LABEL="duckdb/duckdb#${{ steps.vendor.outputs.vendor_rev }}"
@@ -116,7 +112,7 @@ jobs:
 
       - name: Create PR
         id: create_pr
-        if: ${{ steps.prepare_pr_message.outcome == 'success' && steps.check_pr_exists.outputs.pr_exists == 'false' }}
+        if: ${{ steps.check_pr_exists.outputs.pr_exists == 'false' }}
         env:
           # We cannot use default workflow's GITHUB_TOKEN here, because
           # it is restricted to not trigger 'pull_request' event that
@@ -136,7 +132,7 @@ jobs:
 
       - name: Update PR
         id: update_pr
-        if: ${{ steps.prepare_pr_message.outcome == 'success' && steps.check_pr_exists.outputs.pr_exists == 'true' }}
+        if: ${{ steps.check_pr_exists.outputs.pr_exists == 'true' }}
         env:
           # We cannot use default workflow's GITHUB_TOKEN here, because
           # it is restricted to not trigger 'pull_request' event that


### PR DESCRIPTION
This change should fix the check in "Merge vendoring PR" job where the branch name should be taken not from `github.ref_name` (that has the value like `42/merge` where 42 is a PR number), but from `github.base_ref` that contains the branch name on `pull_request` events.

Additionally a few unneded checks are removed from `Vendor.yml`.

Testing: debugged this in JDBC repo