### PR TITLE
Support fetching TIMESTAMPTZ as SQL_TYPE_TIMESTAMP

### DIFF
--- a/include/odbc_utils.hpp
+++ b/include/odbc_utils.hpp
@@ -4,6 +4,7 @@
 // needs to be first because BOOL
 #include "duckdb.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 #ifdef _WIN32
@@ -93,6 +94,8 @@ public:
 	static std::string ConvertSQLCHARToString(SQLCHAR *str);
 	static LPCSTR ConvertStringToLPCSTR(const std::string &str);
 	static SQLCHAR *ConvertStringToSQLCHAR(const std::string &str);
+
+	static int64_t GetUTCOffsetMicrosFromOS(HSTMT hstmt, int64_t utc_micros);
 };
 } // namespace duckdb
 #endif

--- a/src/api_info.cpp
+++ b/src/api_info.cpp
@@ -267,6 +267,8 @@ SQLSMALLINT ApiInfo::FindRelatedSQLType(duckdb::LogicalTypeId type_id) {
 		return SQL_TYPE_DATE;
 	case LogicalTypeId::TIMESTAMP:
 		return SQL_TYPE_TIMESTAMP;
+	case LogicalTypeId::TIMESTAMP_TZ:
+		return SQL_TYPE_TIMESTAMP;
 	case LogicalTypeId::TIME:
 		return SQL_TYPE_TIME;
 	case LogicalTypeId::VARCHAR:

--- a/src/statement/statement_functions.cpp
+++ b/src/statement/statement_functions.cpp
@@ -332,6 +332,11 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 		*str_len_or_ind_ptr = SQL_NULL_DATA;
 		return SQL_SUCCESS;
 	}
+	if (val.type().id() == LogicalType::TIMESTAMP_TZ) {
+		int64_t utc_micros = val.GetValue<int64_t>();
+		int64_t utc_offset_micros = duckdb::OdbcUtils::GetUTCOffsetMicrosFromOS(hstmt, utc_micros);
+		val = Value::TIMESTAMP(timestamp_t(utc_micros + utc_offset_micros));
+	}
 
 	SQLSMALLINT target_type_resolved = target_type;
 	if (target_type_resolved == SQL_C_DEFAULT) {

--- a/test/tests/dotnet-linux/Program.cs
+++ b/test/tests/dotnet-linux/Program.cs
@@ -52,7 +52,7 @@ class Program
             // Date time types
             CheckFileldType(conn, "SELECT '1970-01-01'::Date", "System.DateTime");
             CheckFileldType(conn, "SELECT '12:34'::TIME", "System.TimeSpan");
-            CheckFileldType(conn, "SELECT '2020-01-02 12:34:45+01'::TIMESTAMP WITH TIME ZONE", "System.String");
+            CheckFileldType(conn, "SELECT '2020-01-02 12:34:45+01'::TIMESTAMP WITH TIME ZONE", "System.DateTime");
             CheckFileldType(conn, "SELECT '2020-01-02 12:34:45'::TIMESTAMP WITHOUT TIME ZONE", "System.DateTime");
             CheckFileldType(conn, "SELECT '1 day'::INTERVAL", "System.String");
 

--- a/test/tests/test_timestamp.cpp
+++ b/test/tests/test_timestamp.cpp
@@ -1,5 +1,11 @@
 #include "odbc_test_common.h"
 
+#include <cstdint>
+#include <ctime>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+
 using namespace odbc_test;
 
 TEST_CASE("Test SQLBindParameter with TIMESTAMP type", "[odbc]") {
@@ -161,6 +167,97 @@ TEST_CASE("Test SQLBindParameter with TIME type", "[odbc]") {
 		REQUIRE(fetched.second == param.second);
 		REQUIRE(fetched.fraction == 0);
 	}
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+static std::mutex &get_static_mutex() {
+	static std::mutex mtx;
+	return mtx;
+}
+
+static int64_t os_utc_offset_seconds(const std::string &timestamp_st) {
+	std::mutex &mtx = get_static_mutex();
+	std::lock_guard<std::mutex> guard(mtx);
+	std::tm input_time = {};
+	std::istringstream ss(timestamp_st);
+	ss >> std::get_time(&input_time, "%Y-%m-%d %H:%M:%S");
+	std::time_t input_instant = std::mktime(&input_time);
+	std::tm local_time = *std::localtime(&input_instant);
+	local_time.tm_isdst = 0;
+	std::tm utc_time = *std::gmtime(&input_instant);
+	std::time_t local_instant = std::mktime(&local_time);
+	std::time_t utc_instant = std::mktime(&utc_time);
+	return static_cast<int64_t>(difftime(local_instant, utc_instant));
+}
+
+static std::tm sql_timestamp_to_tm(const SQL_TIMESTAMP_STRUCT &ts) {
+	std::tm dt = {};
+	dt.tm_year = ts.year - 1900;
+	dt.tm_mon = ts.month - 1;
+	dt.tm_mday = ts.day;
+	dt.tm_hour = ts.hour;
+	dt.tm_min = ts.minute;
+	dt.tm_sec = ts.second;
+	return dt;
+}
+
+static int64_t sql_timestamp_diff_seconds(const SQL_TIMESTAMP_STRUCT &ts1, const SQL_TIMESTAMP_STRUCT &ts2) {
+	std::mutex &mtx = get_static_mutex();
+	std::lock_guard<std::mutex> guard(mtx);
+	std::tm tm1 = sql_timestamp_to_tm(ts1);
+	std::tm tm2 = sql_timestamp_to_tm(ts2);
+	std::time_t instant1 = std::mktime(&tm1);
+	std::time_t instant2 = std::mktime(&tm2);
+	return static_cast<int64_t>(std::difftime(instant1, instant2));
+}
+
+TEST_CASE("Test fetching TIMESTAMP_TZ values as TIMESTAMP", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// Connect to the database using SQLConnect
+	CONNECT_TO_DATABASE(env, dbc);
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	std::string tm_local_st = "2004-07-19 10:23:54";
+
+	// Process this date as TIMESTAMP_TZ and fetch is as SQL_C_TYPE_TIMESTAMP,
+	// return value must be converted to local using OS-configured time-zone
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT '" + tm_local_st + "+00'::TIMESTAMP WITH TIME ZONE"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQL_TIMESTAMP_STRUCT fetched_timestamp_tz;
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_TYPE_TIMESTAMP, &fetched_timestamp_tz,
+	                  sizeof(fetched_timestamp_tz), nullptr);
+
+	// Process the same date as TIMESTAMP, no time-zone conversion performed
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT '" + tm_local_st + "'::TIMESTAMP WITHOUT TIME ZONE"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQL_TIMESTAMP_STRUCT fetched_timestamp;
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_TYPE_TIMESTAMP, &fetched_timestamp,
+	                  sizeof(fetched_timestamp), nullptr);
+	REQUIRE(fetched_timestamp.year == 2004);
+	REQUIRE(fetched_timestamp.month == 7);
+	REQUIRE(fetched_timestamp.day == 19);
+	REQUIRE(fetched_timestamp.hour == 10);
+	REQUIRE(fetched_timestamp.minute == 23);
+	REQUIRE(fetched_timestamp.second == 54);
+	REQUIRE(fetched_timestamp.fraction == 0);
+
+	// Get OS time zone offset and compare the fetched results
+	int64_t os_utc_offset = os_utc_offset_seconds(tm_local_st);
+	int64_t fetched_diff = sql_timestamp_diff_seconds(fetched_timestamp_tz, fetched_timestamp);
+	REQUIRE(fetched_diff == os_utc_offset);
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);


### PR DESCRIPTION
DuckDB supports `TIMESTAMP WITH TIME ZONE` data type that stores UTC dates (with specified time zone already applied on DB insert). ODBC does not have a notion of time zones. When client app reads such `TIMESTAMP WITH TIME ZONE` it needs to be converted into `TIMESTAMP WITHOUT TIME ZONE` with client-local time zone applied. And such converted timestamp must represent the same moment of time as stored UTC timestamp.

Applying client-local time zone to timestamp is a non-trivial operation
 - the UTC offset depends on both the time zone (for fixed shift) and on the timestamp value (for DST shift).

There are two options to get the effective offset for the specified UTC timestamp in the specified time zone:

 - DuckDB ICU extension, that will use DB-configured time zone
 - OS API, will use OS-configured time zone

Variant with ICU extension appeared to be problematic, as we would like to not link neither to ICU extension (C++ API, not in DuckDB C API) nor to ICU itself (C API exists, but symbols include ICU major version that can change). We can do ICU call from ODBC by creating SQL string and executing it. But this conversion must be performed for every value in every row. And there no reasonbly-easy ways to cache the results. Thus the idea of SQL calls was rejected.

Variant with OS API matches the approach used in JDBC (see duckdb/duckdb-java#166) where JVM-configured time zone is used (invariant 1 there).

The problem with accessing OS API is that `<ctime>` utilities are not thread-safe until `C++20`. Thus Windows `<timezoneapi.h>` and POSIX `<time.h>` API are used directly. And `<ctime>` approach is used in tests for cross-checking.

Testing: new test added that fetches `TIMESTAMP WITH TIME ZONE` value as `SQL_C_TYPE_TIMESTAMP` and checks that it is shifted correctly.