### PR TITLE
Correct type mappings for .NET numeric types

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -294,7 +294,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y -qq ninja-build unixodbc-dev
+          sudo apt-get install -y -qq ninja-build unixodbc-dev odbcinst dotnet-sdk-8.0
           pip3 install pyodbc
 
       - name: Install nanodbc
@@ -348,6 +348,11 @@ jobs:
       - name: Test Python ODBC
         shell: bash
         run: ./test/run_pyodbc_tests.sh
+
+      - name: Test .NET Linux ODBC
+        shell: bash
+        working-directory: ./test/tests/dotnet-linux
+        run: dotnet run
 
   odbc-merge-vendoring-pr:
     name: Merge vendoring PR 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-.idea
-build
-cmake-build-debug
+/.idea
+/.vscode
+/build
+/cmake-build-debug
+/scripts/__pycache__
+/*.db
+/test/tests/dotnet-linux/bin
+/test/tests/dotnet-linux/obj
+/test/sql/storage_version/storage_version.dbtest.duckdb

--- a/include/api_info.hpp
+++ b/include/api_info.hpp
@@ -78,7 +78,13 @@ public:
 		switch (sql_type) {
 		case SQL_DECIMAL:
 		case SQL_NUMERIC:
-			return duckdb::DecimalType::GetWidth(logical_type) + duckdb::DecimalType::GetScale(logical_type);
+			switch (logical_type.id()) {
+				case LogicalType::HUGEINT:
+				case LogicalType::UHUGEINT:
+					return 39;
+				default:
+					return duckdb::DecimalType::GetWidth(logical_type) + duckdb::DecimalType::GetScale(logical_type);
+			}
 		case SQL_BIT:
 			return 1;
 		case SQL_TINYINT:

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -100,6 +100,8 @@ ignored_files = [
 ignored_directories = [
     'src/duckdb',
     'scripts/__pycache__',
+    'test/tests/dotnet',
+    'test/tests/dotnet-linux',
 ]
 format_all = False
 check_only = True

--- a/src/api_info.cpp
+++ b/src/api_info.cpp
@@ -255,9 +255,12 @@ SQLSMALLINT ApiInfo::FindRelatedSQLType(duckdb::LogicalTypeId type_id) {
 		return SQL_BIGINT;
 	case LogicalTypeId::UBIGINT:
 		return SQL_BIGINT;
+	case LogicalTypeId::HUGEINT:
+		return SQL_NUMERIC;
+	case LogicalTypeId::UHUGEINT:
+		return SQL_NUMERIC;
 	case LogicalTypeId::FLOAT:
 		return SQL_FLOAT;
-	case LogicalTypeId::HUGEINT:
 	case LogicalTypeId::DOUBLE:
 		return SQL_DOUBLE;
 	case LogicalTypeId::DATE:
@@ -273,7 +276,7 @@ SQLSMALLINT ApiInfo::FindRelatedSQLType(duckdb::LogicalTypeId type_id) {
 	case LogicalTypeId::INTERVAL:
 		return SQL_INTERVAL;
 	case LogicalTypeId::DECIMAL:
-		return SQL_DOUBLE;
+		return SQL_DECIMAL;
 	case LogicalTypeId::LIST:
 		return SQL_VARCHAR;
 	case LogicalTypeId::BIT:

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -101,8 +101,9 @@ string OdbcUtils::GetQueryDuckdbColumns(const string &catalog_filter, const stri
                 'UINTEGER': 4, -- SQL_INTEGER
                 'BIGINT': -5, -- SQL_BIGINT
                 'UBIGINT': -5, -- SQL_BIGINT
+                'HUGEINT': 2, -- SQL_NUMERIC
+                'UHUGEINT': 2, -- SQL_NUMERIC
                 'FLOAT': 6, -- SQL_FLOAT
-                'HUGEINT': 8, -- SQL_DOUBLE
                 'DOUBLE': 8, -- SQL_DOUBLE
                 'DATE': 91, -- SQL_TYPE_DATE
                 'TIMESTAMP': 93, -- SQL_TYPE_TIMESTAMP

--- a/test/tests/dotnet-linux/Program.cs
+++ b/test/tests/dotnet-linux/Program.cs
@@ -1,0 +1,69 @@
+﻿using System.Data.Odbc;
+
+class Program
+{
+    public static void AssertEquals(string expected, string actual)
+    {
+        if (!string.Equals(expected, actual, StringComparison.Ordinal))
+        {
+            throw new Exception($"Assertion failed. Expected: '{expected}', Actual: '{actual}'");
+        }
+    }
+
+    static void CheckFileldType(OdbcConnection connection, string sql, string expectedDataType)
+    {
+        using (OdbcCommand command = connection.CreateCommand())
+        {
+            command.CommandText = sql;
+            using (OdbcDataReader reader = command.ExecuteReader())
+            {
+                reader.Read();
+                AssertEquals(expectedDataType, reader.GetFieldType(0).ToString());
+            }
+        }
+    }
+
+    static void Main(string[] args)
+    {
+        using (OdbcConnection conn = new OdbcConnection("Driver={DuckDB Driver}"))
+        {
+            conn.Open();
+
+            // Integer types
+            CheckFileldType(conn, "SELECT 1::TINYINT", "System.Int16"); // SByte in OleDB
+            CheckFileldType(conn, "SELECT 1::UTINYINT", "System.Byte");
+            CheckFileldType(conn, "SELECT 1::SMALLINT", "System.Int16");
+            CheckFileldType(conn, "SELECT 1::USMALLINT", "System.Int32"); // UInt16 in OleDB
+            CheckFileldType(conn, "SELECT 1::INTEGER", "System.Int32");
+            CheckFileldType(conn, "SELECT 1::UINTEGER", "System.Int64"); // Uint32 in OldDb
+            CheckFileldType(conn, "SELECT 1::BIGINT", "System.Int64");
+            CheckFileldType(conn, "SELECT 1::UBIGINT", "System.Decimal"); // Uint64 in OleDb
+            CheckFileldType(conn, "SELECT 1::HUGEINT", "System.Decimal");
+            CheckFileldType(conn, "SELECT 1::UHUGEINT", "System.Decimal");
+
+            // Decimal types
+            CheckFileldType(conn, "SELECT '1'::DECIMAL(18,3)", "System.Decimal");
+            CheckFileldType(conn, "SELECT '1'::NUMERIC(18,3)", "System.Decimal");
+
+            // Boolean types
+            CheckFileldType(conn, "SELECT 1::BIT", "System.Boolean");
+            CheckFileldType(conn, "SELECT true::BOOLEAN", "System.String");
+
+            // Date time types
+            CheckFileldType(conn, "SELECT '1970-01-01'::Date", "System.DateTime");
+            CheckFileldType(conn, "SELECT '12:34'::TIME", "System.TimeSpan");
+            CheckFileldType(conn, "SELECT '2020-01-02 12:34:45+01'::TIMESTAMP WITH TIME ZONE", "System.String");
+            CheckFileldType(conn, "SELECT '2020-01-02 12:34:45'::TIMESTAMP WITHOUT TIME ZONE", "System.DateTime");
+            CheckFileldType(conn, "SELECT '1 day'::INTERVAL", "System.String");
+
+            // Other types
+            CheckFileldType(conn, "SELECT ''::BLOB", "System.Byte[]");
+            CheckFileldType(conn, "SELECT '{}'::JSON", "System.String");
+            CheckFileldType(conn, "SELECT '516d4db7-075d-419d-8d25-49dc4d7946aa'::UUID", "System.String");
+            CheckFileldType(conn, "SELECT ''::VARCHAR", "System.String");
+
+        }
+
+        Console.WriteLine("dotnet-linux tests passed successfully");
+    }
+}

--- a/test/tests/dotnet-linux/README.md
+++ b/test/tests/dotnet-linux/README.md
@@ -1,0 +1,11 @@
+System.Data.Odbc tests for .NET on Linux
+----------------------------------------
+
+To run tests on Ubuntu-22.04 add `[DuckDB Driver]` to `odbcinst.ini` and run:
+
+```
+sudo apt install unixodbc-dev dotnet-sdk-8.0
+dotnet run
+```
+
+On newer versions of Linux the version of `TargetFramework` in `dotnet.csproj` may need to be corrected to match installed SDK.

--- a/test/tests/dotnet-linux/dotnet.csproj
+++ b/test/tests/dotnet-linux/dotnet.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Data.Odbc" Version="9.0.4" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR correct the type mapping changing the ODBC type to `SQL_DECIMAL` for the following DuckDB types:

 - `UBIGINT`
 - `HUGEINT`
 - `UHUGEINT`
 - `DECIMAL`

.NET CLS type for these DB types is now `System.Decimal`.

Testing: new test-suite is added using `dotnet` on Linux. Currently it only covers the type mapping from `OdbcConnection` to .NET CLS types. It overlaps with existing Windows `dotnet` test-suite, but it appeared challenging to iterate over Windows `dotnet` due to long compile times on Windows. New test-suite is confirmed to work on Ubuntu-22.04 and Fedora. It is added to `ODBC Tests` CI run.

Fixes: #93