### PR TITLE
Do not create unneeded threads for default DB

### DIFF
--- a/include/duckdb_odbc.hpp
+++ b/include/duckdb_odbc.hpp
@@ -47,6 +47,7 @@ struct OdbcHandleEnv : public OdbcHandle {
 	OdbcHandleEnv() : OdbcHandle(OdbcHandleType::ENV) {
 		duckdb::DBConfig ODBC_CONFIG;
 		ODBC_CONFIG.SetOptionByName("duckdb_api", "odbc");
+		ODBC_CONFIG.SetOptionByName("threads", 1);
 		db = make_shared_ptr<DuckDB>(nullptr, &ODBC_CONFIG);
 	};
 


### PR DESCRIPTION
I was debugging another issue and stumbled upon this behaviour of `OdbcHandleEnv`: when client app calls `SQLDriverConnect` the Driver Manager allocates the `ENV` handle before calling `SQLDriverConnect` on the driver. When `ENV` handle is allocated - default in-memory instance of DuckDB is initialized. With default settings it creates a number of worker threads (the same as CPU-count). When `SQLDriverConnect` is called immmediately after that - new DB instance is created (with its own set of worker threads) and the default one is destroyed.

This change adds `threads=1` config option to default DB to prevent additional threads creation. It shoult improve startup time a little and should not affect any existing logic.

Testing: new test is added to check that `threads=1` config is not inadvertently applied to actual DB instance.