### PR TITLE
Allow query execution with unbound parameters

### DIFF
--- a/src/statement/statement_functions.cpp
+++ b/src/statement/statement_functions.cpp
@@ -19,6 +19,7 @@
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
 
 using duckdb::date_t;
 using duckdb::Decimal;
@@ -54,22 +55,38 @@ string duckdb::GetQueryAsString(duckdb::OdbcHandleStmt *hstmt, SQLCHAR *statemen
 }
 
 SQLRETURN duckdb::FinalizeStmt(duckdb::OdbcHandleStmt *hstmt) {
-	if (hstmt->stmt->data && !hstmt->stmt->GetStatementProperties().bound_all_parameters) {
-		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", "Not all parameters are bound",
-		                            SQLStateType::ST_42000, hstmt->dbc->GetDataSourceName()));
-	}
 	if (hstmt->stmt->HasError()) {
-		return (SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", hstmt->stmt->error.Message(),
-		                            SQLStateType::ST_42000, hstmt->dbc->GetDataSourceName()));
+		return SetDiagnosticRecord(hstmt, SQL_ERROR, "PrepareStmt", hstmt->stmt->error.Message(),
+		                           SQLStateType::ST_42000, hstmt->dbc->GetDataSourceName());
 	}
 
+	D_ASSERT(hstmt->stmt->data);
+
+	SQLRETURN ret = SQL_SUCCESS;
+
+	// Prepare call may be unable to bind the query when parameter types cannot be determined,
+	// for example: 'SELECT ?'.
+	// In this case the plan is not created at all and resulting columns (their types and names)
+	// returned with a partially-filled state, so we need to clear them. They are going to be re-filled after
+	// each execution and may be different depending on input parameters supplied for execution.
+	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+		hstmt->stmt->data->types.clear();
+		hstmt->stmt->data->names.clear();
+		ret = SetDiagnosticRecord(hstmt, SQL_SUCCESS_WITH_INFO, "PrepareStmt", "Not all parameters are bound",
+		                          SQLStateType::ST_01000, hstmt->dbc->GetDataSourceName());
+	}
+
+	// named_param_map is created on successfull parse stage, does not need to be corrected on rebind
 	hstmt->param_desc->ResetParams(static_cast<SQLSMALLINT>(hstmt->stmt->named_param_map.size()));
 
+	// Bounded columns and IRD records depend on resulting columns, in case when
+	// bound_all_parameters=false, we don't have resulting columns defined, then
+	// bounded columns and IRD records are kept empty and being re-filled after
+	// every execution
 	hstmt->bound_cols.resize(hstmt->stmt->ColumnCount());
-
 	hstmt->FillIRD();
 
-	return SQL_SUCCESS;
+	return ret;
 }
 
 //! Execute stmt in a batch manner while there is a parameter set to process,
@@ -80,13 +97,32 @@ SQLRETURN duckdb::BatchExecuteStmt(duckdb::OdbcHandleStmt *hstmt) {
 		ret = SingleExecuteStmt(hstmt);
 	} while (ret == SQL_STILL_EXECUTING);
 
-	// now, fetching the first chunk to verify constant folding (See: PR #2462 and issue #2452)
-	if (ret == SQL_SUCCESS) {
-		auto fetch_ret = hstmt->odbc_fetcher->FetchFirst(hstmt);
-		if (fetch_ret == SQL_ERROR) {
-			return fetch_ret;
-		}
+	// Early exit on error
+	if (!SQL_SUCCEEDED(ret)) {
+		return ret;
 	}
+
+	// now, fetching the first chunk to verify constant folding (See: PR #2462 and issue #2452)
+	auto fetch_ret = hstmt->odbc_fetcher->FetchFirst(hstmt);
+	if (fetch_ret == SQL_ERROR) {
+		return fetch_ret;
+	}
+
+	// When parameters were not bound (plan was not created) on Prepare call, then
+	// we need to correct IRD records after every execution
+	if (!hstmt->stmt->GetStatementProperties().bound_all_parameters) {
+		D_ASSERT(hstmt->stmt->data);
+		D_ASSERT(hstmt->res);
+
+		// Copy up to date result types and names from the execution result
+		hstmt->stmt->data->types = hstmt->res->types;
+		hstmt->stmt->data->names = hstmt->res->names;
+
+		// Correct bounded columns and re-fill IRD records
+		hstmt->bound_cols.resize(hstmt->stmt->ColumnCount());
+		hstmt->FillIRD();
+	}
+
 	return ret;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   tests/result_conversion.cpp
   tests/test_allowed_paths.cpp
   tests/test_timestamp.cpp
+  tests/test_unbound_params.cpp
   tests/test_widechar_conv.cpp
   tests/test_widechar_data.cpp
   tests/col_attribute/col_attribute.cpp

--- a/test/tests/select.cpp
+++ b/test/tests/select.cpp
@@ -50,15 +50,6 @@ TEST_CASE("Test Select Statement", "[odbc]") {
 		DATA_CHECK(hstmt, i, std::to_string(i));
 	}
 
-	// SELECT $x; should throw error
-	SQLRETURN ret = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT $x"), SQL_NTS);
-	REQUIRE(ret == SQL_ERROR);
-	std::string state;
-	std::string message;
-	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
-	REQUIRE(state == "42000");
-	REQUIRE(duckdb::StringUtil::Contains(message, "Not all parameters are bound"));
-
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
 	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
@@ -113,15 +104,6 @@ TEST_CASE("Test Select Statement Wide", "[odbc]") {
 	for (int i = 1; i < 1600; i++) {
 		DATA_CHECK(hstmt, i, std::to_string(i));
 	}
-
-	// SELECT $x; should throw error
-	SQLRETURN ret = SQLExecDirectW(hstmt, ConvertToSQLWCHARNTS("SELECT $x").data(), SQL_NTS);
-	REQUIRE(ret == SQL_ERROR);
-	std::string state;
-	std::string message;
-	ACCESS_DIAGNOSTIC(state, message, hstmt, SQL_HANDLE_STMT);
-	REQUIRE(state == "42000");
-	REQUIRE(duckdb::StringUtil::Contains(message, "Not all parameters are bound"));
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);

--- a/test/tests/test_unbound_params.cpp
+++ b/test/tests/test_unbound_params.cpp
@@ -1,0 +1,150 @@
+#include "odbc_test_common.h"
+
+using namespace odbc_test;
+
+TEST_CASE("Test 'bound_all_parameters=false' case with SQLExecDirect", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	// Connect to the database using SQLConnect
+	CONNECT_TO_DATABASE(env, dbc);
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	// Supply parameters
+	int32_t param1 = 42;
+	SQLLEN param1_len = sizeof(param1);
+	EXECUTE_AND_CHECK("SQLBindParameter (param)", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_SLONG,
+	                  SQL_INTEGER, 0, 0, &param1, param1_len, &param1_len);
+	std::string param2 = "foo";
+	SQLLEN param2_len = param2.length();
+	EXECUTE_AND_CHECK("SQLBindParameter (param)", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_CHAR,
+	                  SQL_VARCHAR, param2_len, 0, const_cast<char *>(param2.c_str()), param2_len, &param2_len);
+
+	// Run the query
+	SQLRETURN ret_exec = SQLExecDirect(hstmt, ConvertToSQLCHAR("SELECT ?, ?"), SQL_NTS);
+	REQUIRE(ret_exec == SQL_SUCCESS_WITH_INFO);
+
+	// Check that IRD was re-filled correctly
+	SQLLEN ctype = -1;
+	EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_CONCISE_TYPE, nullptr, 0, nullptr,
+	                  &ctype);
+	REQUIRE(ctype == SQL_INTEGER);
+	EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 2, SQL_DESC_CONCISE_TYPE, nullptr, 0, nullptr,
+	                  &ctype);
+	REQUIRE(ctype == SQL_VARCHAR);
+
+	// Fetch and check the data
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	int32_t fetched1 = -1;
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_SLONG, &fetched1, sizeof(fetched1), nullptr);
+	REQUIRE(fetched1 == param1);
+	std::vector<char> fetched2(64);
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, fetched2.data(), sizeof(fetched2),
+	                  nullptr);
+	REQUIRE(std::string(fetched2.data()) == param2);
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test 'bound_all_parameters=false' case with SQLPrepare and SQLExecute", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	int32_t param1 = 42;
+	SQLLEN param1_len = sizeof(param1);
+	std::string param2 = "foo";
+	SQLLEN param2_len = param2.length();
+
+	// Connect to the database using SQLConnect
+	CONNECT_TO_DATABASE(env, dbc);
+
+	// Allocate a statement handle
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	// Prepare the query
+	SQLRETURN ret_prepare = SQLPrepare(hstmt, ConvertToSQLCHAR("SELECT ?, ?"), SQL_NTS);
+	REQUIRE(ret_prepare == SQL_SUCCESS_WITH_INFO);
+
+	// Supply parameters
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER,
+	                  0, 0, &param1, param1_len, &param1_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	                  param2_len, 0, const_cast<char *>(param2.c_str()), param2_len, &param2_len);
+
+	// Run the query
+	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+
+	// Check that IRD was re-filled correctly
+	{
+		SQLLEN ctype = -1;
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_CONCISE_TYPE, nullptr, 0,
+		                  nullptr, &ctype);
+		REQUIRE(ctype == SQL_INTEGER);
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 2, SQL_DESC_CONCISE_TYPE, nullptr, 0,
+		                  nullptr, &ctype);
+		REQUIRE(ctype == SQL_VARCHAR);
+	}
+
+	// Fetch and check the data
+	{
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+		int32_t fetched1 = -1;
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_SLONG, &fetched1, sizeof(fetched1), nullptr);
+		REQUIRE(fetched1 == param1);
+		std::vector<char> fetched2(64);
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_CHAR, fetched2.data(), sizeof(fetched2),
+		                  nullptr);
+		REQUIRE(std::string(fetched2.data()) == param2);
+	}
+
+	// Reset parameters. TODO: investigate why this is required
+	EXECUTE_AND_CHECK("SQLFreeStmt (PARAMS)", hstmt, SQLFreeStmt, hstmt, SQL_RESET_PARAMS);
+
+	// Supply parameters in reverse order
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR, SQL_VARCHAR,
+	                  param2_len, 0, const_cast<char *>(param2.c_str()), param2_len, &param2_len);
+	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 2, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER,
+	                  0, 0, &param1, param1_len, &param1_len);
+
+	// Run the query
+	EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+
+	// Check that IRD was re-filled correctly
+	{
+		SQLLEN ctype = -1;
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 1, SQL_DESC_CONCISE_TYPE, nullptr, 0,
+		                  nullptr, &ctype);
+		REQUIRE(ctype == SQL_VARCHAR);
+		EXECUTE_AND_CHECK("SQLColAttribute", hstmt, SQLColAttribute, hstmt, 2, SQL_DESC_CONCISE_TYPE, nullptr, 0,
+		                  nullptr, &ctype);
+		REQUIRE(ctype == SQL_INTEGER);
+	}
+
+	// Fetch and check the data
+	{
+		EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+		std::vector<char> fetched1(64);
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_CHAR, fetched1.data(), sizeof(fetched1),
+		                  nullptr);
+		REQUIRE(std::string(fetched1.data()) == param2);
+		int32_t fetched2 = -1;
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 2, SQL_C_SLONG, &fetched2, sizeof(fetched2), nullptr);
+		REQUIRE(fetched2 == param1);
+	}
+
+	// Free the statement handle
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}


### PR DESCRIPTION
When a query is prepared, DuckDB, among other things, determines the column types of the result set. In some cases it is not possible to determine column types based on the query text alone, for example:

```
SELECT ?
```

In such cases the resulting column type will be different depending on the parameter value provided, that can be aso different between the executions of the same prepared query.

In such cases DuckDB does not create the query plan when query is prepared and instead marks the statement with "unbound parameters" marker.

In our ODBC impl there is a strict check that query preparation must produce the plan and "unbound parameters" queries are rejected. The "prepare" call is the same for both `SQLExecDirect` and `SQLPrepare` + `SQLExecute` cases. Even when the client supplies parameter values before calling `SQLExecDirect`, DuckDB does not have API to pass these parameters to "prepare" call.

Proposed change removed the strict check for "unbound parameters" queries allowing them to be executed. It corrects the logic around Implementation Row Descriptor (IRD - description of result set columns) records, so for "unbound parameters" queries these IRD records are kept empty until the query is executed, and then re-filled after every execution.

This change should not affect the logic for normal queries (where all parameters are bound) so should not break any existing working use-cases.

Testing: new test is added that covers unbound parameters case with both `SQLExecDirect` and `SQLPrepare` + `SQLExecute` approaches.

Fixes: #119