### PR TITLE
Fix vendoring PRs for stable branches (1.3)

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -394,7 +394,7 @@ jobs:
         run: |
             # Delete vendoring-${{ github.base_ref }} branch and re-create it for future PRs
             git push --delete origin vendoring-${{ github.base_ref }}
-            git checkout --track origin/main
+            git checkout --track origin/${{ github.base_ref }}
             git pull --ff-only
             git branch vendoring-${{ github.base_ref }}
             git push origin vendoring-${{ github.base_ref }}


### PR DESCRIPTION
This is a backport of the PR #151 to `v1.3-ossivalis` stable branch.

Nightly import of DuckDB engine sources ("vendoring") is performed by creating PRs on `vendoring-<branch>` base branches. After the tests are passed the PR is merged and `vendoring-<branch>` is re-created to be used in subsequent imports.

This change fixes the vendoring branch re-creation to place it not always on the `main` branch, but on the correct branch (either `main` or stable one line `v1.3-ossivalis`).