### PR TITLE
Enable macOS check for vendoring PR merge

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -276,9 +276,6 @@ jobs:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install Ninja
-        run: brew install ninja
-
       - name: Install UnixODBC
         shell: bash
         run: CFLAGS="-arch x86_64 -arch arm64" ./scripts/install_unixodbc.sh
@@ -396,6 +393,7 @@ jobs:
       - odbc-linux-amd64
       - odbc-linux-aarch64
       - odbc-windows-amd64
+      - odbc-osx-universal
       - debug
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Vendoring (engine source import) PRs are merged automatically after tests are passed for all platforms.

This change fixes the oversight where macOS tests were ignored in checks for merging vendoring PRs.