### PR TITLE
Enable macOS check for vendoring PR merge (1.3)

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -250,9 +250,6 @@ jobs:
           key: ${{ github.job }}
           save: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Install Ninja
-        run: brew install ninja
-
       - name: Install UnixODBC
         shell: bash
         run: CFLAGS="-arch x86_64 -arch arm64" ./scripts/install_unixodbc.sh
@@ -370,6 +367,7 @@ jobs:
       - odbc-linux-amd64
       - odbc-linux-aarch64
       - odbc-windows-amd64
+      - odbc-osx-universal
       - debug
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is a backport of the PR #153 to `v1.3-ossivalis` stable branch.

Vendoring (engine source import) PRs are merged automatically after tests are passed for all platforms.

This change fixes the oversight where macOS tests were ignored in checks for merging vendoring PRs.