### PR TITLE
Exclude test runnners from Windows bundle

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -244,7 +244,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
           choco install zip -y --force
-          zip -j duckdb_odbc-windows-amd64.zip ./build/release/bin/Release/*
+          zip -j duckdb_odbc-windows-amd64.zip                \
+            ./build/release/bin/Release/duckdb_odbc.dll       \
+            ./build/release/bin/Release/duckdb_odbc_setup.dll \
+            ./build/release/bin/Release/odbc_install.exe
           ./scripts/upload-assets-to-staging.sh github_release duckdb_odbc-windows-amd64.zip
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This change excludes test runner EXEs from `duckdb_odbc-windows-amd64.zip` bundle because these runners are only useful when the source tree is present.