### PR TITLE
Update GH Windows runners (1.3)

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -114,7 +114,7 @@ jobs:
 
   odbc-windows-amd64:
     name: ODBC Windows (amd64)
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: odbc-linux-amd64
     env:
       AZURE_CODESIGN_ENDPOINT: https://eus.codesigning.azure.net/

--- a/test/tests/dotnet/CMakeLists.txt
+++ b/test/tests/dotnet/CMakeLists.txt
@@ -24,4 +24,3 @@ list(APPEND VS_DOTNET_REFERENCES "System.Xml.Linq")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DOTNET_REFERENCES
                                                  "${VS_DOTNET_REFERENCES}")
-set_target_properties(${PROJECT_NAME} PROPERTIES DOTNET_TARGET_FRAMEWORK net472)


### PR DESCRIPTION
This is a backport of the PR #143 to `v1.3-ossivalis` stable branch.

Windows runnner images are changed from `windows-2019` to `windows-latest` due to actions/runner-images#12045.

Use of .NET SDK 4.7.2 in tests was added before for `windows-2019`, so this bit is removed too.