### PR TITLE
Support catalog name in SQLTables (1.3)

### DIFF
--- a/include/odbc_utils.hpp
+++ b/include/odbc_utils.hpp
@@ -85,7 +85,7 @@ public:
 	static std::string ParseStringFilter(const std::string &filter_name, const std::string &filter_value,
 	                                     SQLUINTEGER sql_attr_metadata_id, const std::string &coalesce_str = "");
 
-	static std::string GetQueryDuckdbTables(const std::string &schema_filter, const std::string &table_filter,
+	static std::string GetQueryDuckdbTables(const std::string &catalog_filter, const std::string &schema_filter, const std::string &table_filter,
 	                                        const std::string &table_type_filter);
 	static std::string GetQueryDuckdbColumns(const std::string &catalog_filter, const std::string &schema_filter,
 	                                         const std::string &table_filter, const std::string &column_filter);

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -111,6 +111,22 @@ void DATA_CHECK(HSTMT &hstmt, SQLSMALLINT col_num, const std::string &expected_c
 	REQUIRE(ConvertToString(content) == expected_content);
 }
 
+void DATA_CHECK_WIDE(HSTMT &hstmt, SQLSMALLINT col_num, const std::string &expected_content) {
+	std::vector<SQLWCHAR> content;
+	content.resize(256);
+	SQLLEN content_len = -1;
+
+	// SQLGetData returns data for a single column in the result set.
+	SQLRETURN ret =
+	    SQLGetData(hstmt, col_num, SQL_C_WCHAR, content.data(), content.size() * sizeof(SQLWCHAR), &content_len);
+	ODBC_CHECK(ret, "SQLGetData (wide)", hstmt);
+	if (content_len == SQL_NULL_DATA) {
+		REQUIRE(expected_content.empty());
+		return;
+	}
+	REQUIRE(ConvertToString(content.data()) == expected_content);
+}
+
 void METADATA_CHECK(HSTMT &hstmt, SQLUSMALLINT col_num, const std::string &expected_col_name,
                     SQLSMALLINT expected_col_name_len, SQLSMALLINT expected_col_data_type, SQLULEN expected_col_size,
                     SQLSMALLINT expected_col_decimal_digits, SQLSMALLINT expected_col_nullable) {

--- a/test/include/odbc_test_common.h
+++ b/test/include/odbc_test_common.h
@@ -62,6 +62,17 @@ void DATA_CHECK(HSTMT &hstmt, SQLSMALLINT col_num, const std::string &expected_c
 
 /**
  * @brief
+ * Runs SQLGetData to get the data in UTF-16 from the column of the current row, converts it to UTF-8
+ * and compares it with the expected content.
+ *
+ * @param hstmt A statement handle
+ * @param col_num The number of the column in the result set
+ * @param expected_content The expected content of the column
+ */
+void DATA_CHECK_WIDE(HSTMT &hstmt, SQLSMALLINT col_num, const std::string &expected_content);
+
+/**
+ * @brief
  * Runs SQLDescribeCol to get the metadata of the column and compares it with the expected metadata.
  * If the expected metadata is not provided (ie empty or NULL), the function won't check for it.
  *


### PR DESCRIPTION
This is a backport of the PR #140 to `v1.3-ossivalis` stable branch.

This change adds support for `CatalogName` parameter in `SQLTables` call that was previously ignored. It is handled the same way as `SchemaName` and `TableName` parameters.

Additionally it fixes special cases in `SQLTables` when only catalogs, schemas or table types are listed.

Testing: existing test is updated to cover catalog filtering and all special cases.

Fixes: #134