### PR TITLE
Support connection strings without null-term (1.3)

### DIFF
--- a/include/odbc_utils.hpp
+++ b/include/odbc_utils.hpp
@@ -91,7 +91,7 @@ public:
 	                                         const std::string &table_filter, const std::string &column_filter);
 
 	static SQLUINTEGER SQLPointerToSQLUInteger(SQLPOINTER value);
-	static std::string ConvertSQLCHARToString(SQLCHAR *str);
+	static std::string ConvertSQLCHARToString(SQLCHAR *str, SQLSMALLINT str_len);
 	static LPCSTR ConvertStringToLPCSTR(const std::string &str);
 	static SQLCHAR *ConvertStringToSQLCHAR(const std::string &str);
 

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -262,8 +262,13 @@ SQLUINTEGER OdbcUtils::SQLPointerToSQLUInteger(SQLPOINTER value) {
 	return static_cast<SQLUINTEGER>(reinterpret_cast<SQLULEN>(value));
 }
 
-std::string OdbcUtils::ConvertSQLCHARToString(SQLCHAR *str) {
-	return std::string(reinterpret_cast<char *>(str));
+std::string OdbcUtils::ConvertSQLCHARToString(SQLCHAR *str, SQLSMALLINT str_len) {
+	if (str_len == SQL_NTS) {
+		return std::string(reinterpret_cast<char *>(str));
+	} else {
+		std::size_t len = str_len > 0 ? static_cast<std::size_t>(str_len) : 0;
+		return std::string(reinterpret_cast<char *>(str), len);
+	}
 }
 
 LPCSTR OdbcUtils::ConvertStringToLPCSTR(const std::string &str) {

--- a/src/connect/connect.cpp
+++ b/src/connect/connect.cpp
@@ -171,16 +171,16 @@ SQLRETURN Connect::SetConnection() {
 	NormalizeWindowsPathSeparators(config_map, "allowed_directories");
 #endif // _WIN32
 
-	// Validate and set all options
-	config.SetOptionsByName(config_map);
-
-	if (!enable_external_access.empty()) {
-		config.SetOptionByName("enable_external_access", duckdb::Value(enable_external_access));
-	}
-
-	bool cache_instance = database != IN_MEMORY_PATH;
-
 	try {
+		// Validate and set all options
+		config.SetOptionsByName(config_map);
+
+		if (!enable_external_access.empty()) {
+			config.SetOptionByName("enable_external_access", duckdb::Value(enable_external_access));
+		}
+
+		bool cache_instance = database != IN_MEMORY_PATH;
+
 		dbc->env->db = instance_cache.GetOrCreateInstance(database, config, cache_instance);
 	} catch (std::exception &ex) {
 		ErrorData error(ex);

--- a/src/connect/driver_connect.cpp
+++ b/src/connect/driver_connect.cpp
@@ -29,7 +29,7 @@ static SQLRETURN DriverConnectInternal(SQLHDBC connection_handle, SQLHWND window
 		return ret;
 	}
 
-	const std::string in_conn_str = OdbcUtils::ConvertSQLCHARToString(in_connection_string);
+	const std::string in_conn_str = OdbcUtils::ConvertSQLCHARToString(in_connection_string, string_length1);
 	duckdb::Connect connect(dbc, in_conn_str);
 
 	ret = connect.ParseInputStr();
@@ -86,8 +86,9 @@ static SQLRETURN ConnectInternal(SQLHDBC connection_handle, SQLCHAR *server_name
 		return ret;
 	}
 
-	dbc->dsn = OdbcUtils::ConvertSQLCHARToString(server_name);
-	duckdb::Connect connect(dbc, OdbcUtils::ConvertSQLCHARToString(server_name));
+	std::string server_name_st = OdbcUtils::ConvertSQLCHARToString(server_name, name_length1);
+	dbc->dsn = server_name_st;
+	duckdb::Connect connect(dbc, server_name_st);
 
 	return connect.SetConnection();
 }


### PR DESCRIPTION
This is a backport of the PR #146 to `v1.3-ossivalis` stable branch.

This change makes `SQLDriverConnect` (and `SQLConnect`) calls to honour the connection string length passed by client.

Testing: new test added.

Fixes: #145