### PR TITLE
Support running an SQL file on init (1.3)

### DIFF
--- a/include/connect.hpp
+++ b/include/connect.hpp
@@ -26,6 +26,8 @@ public:
 	SQLRETURN ReadFromIniFile();
 	// Executes the connection
 	SQLRETURN SetConnection();
+	std::string GetOptionFromConfigMap(const std::string &key, const std::string &default_val = std::string());
+	void NormalizeWindowsPathSeparators(const std::string &option_name);
 
 	// getters
 	std::string GetInputStr() {

--- a/include/file_io.hpp
+++ b/include/file_io.hpp
@@ -1,0 +1,30 @@
+#ifndef DUCKDB_FILE_IO_HPP
+#define DUCKDB_FILE_IO_HPP
+
+#include <cstddef>
+#include <exception>
+#include <string>
+  
+namespace duckdb {
+
+bool FileExists(const std::string &path);
+
+std::size_t FileSizeBytes(const std::string &path);
+
+std::string FileReadToString(const std::string &path, std::size_t max_size_bytes);
+
+class FileIOException : public std::exception {
+public:
+    explicit FileIOException(std::string msg)
+        : message(std::move(msg)) {}
+
+    const char* what() const noexcept override {
+        return message.c_str();
+    }
+
+private:
+    std::string message;
+};
+
+} // namespace duckdb
+#endif // DUCKDB_FILE_IO_HPP

--- a/include/odbc_utils.hpp
+++ b/include/odbc_utils.hpp
@@ -96,6 +96,8 @@ public:
 	static SQLCHAR *ConvertStringToSQLCHAR(const std::string &str);
 
 	static int64_t GetUTCOffsetMicrosFromOS(HSTMT hstmt, int64_t utc_micros);
+
+	static std::string TrimString(const std::string& str);
 };
 } // namespace duckdb
 #endif

--- a/include/session_init.hpp
+++ b/include/session_init.hpp
@@ -1,0 +1,38 @@
+#ifndef DUCKDB_SESSION_INIT_H
+#define DUCKDB_SESSION_INIT_H
+
+#include <string>
+  
+#include "duckdb_odbc.hpp"
+
+namespace duckdb {
+
+class SessionInitSQLFile {
+public:
+  static const std::size_t SQL_FILE_MAX_SIZE_BYTES;
+  static const std::string CONN_INIT_MARKER;
+
+  std::string db_init_sql;
+  std::string conn_init_sql;
+  std::string orig_file_text;
+
+  SessionInitSQLFile();
+
+  SessionInitSQLFile(std::string db_init_sql_in, std::string conn_init_sql_in, std::string orig_file_text_in);
+
+  bool IsEmpty();
+};
+
+class SessionInit {
+public:
+  static const std::string SQL_FILE_OPTION;
+  static const std::string SQL_FILE_SHA256_OPTION;
+
+  static SessionInitSQLFile ReadSQLFile(const std::string &session_init_sql_file, const std::string &session_init_sql_file_sha256);
+
+  static SQLRETURN Run(OdbcHandleDbc *dbc, const SessionInitSQLFile &sql_file, bool db_created);
+};
+
+} // namespace duckdb
+
+#endif // DUCKDB_SESSION_INIT_H 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_library(
-  odbc_common OBJECT duckdb_odbc.cpp handle_functions.cpp odbc_diagnostic.cpp
-                     odbc_fetch.cpp odbc_interval.cpp odbc_utils.cpp)
+  odbc_common OBJECT
+  duckdb_odbc.cpp
+  file_io.cpp
+  handle_functions.cpp
+  odbc_diagnostic.cpp
+  odbc_fetch.cpp
+  odbc_interval.cpp
+  odbc_utils.cpp)
 
 target_compile_definitions(odbc_common PRIVATE -DDUCKDB_STATIC_BUILD)
 

--- a/src/common/file_io.cpp
+++ b/src/common/file_io.cpp
@@ -1,0 +1,96 @@
+#include "file_io.hpp"
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/stat.h>
+#endif // !_WIN32
+
+#include <fstream>
+
+#include "widechar.hpp"
+
+namespace duckdb {
+
+#ifdef _WIN32
+static std::wstring WidenStr(const std::string &str) {
+	const SQLCHAR *first_invalid_char = nullptr;
+	const SQLCHAR *str_ptr = reinterpret_cast<const SQLCHAR *>(str.data());
+	std::vector<SQLWCHAR> vec = widechar::utf8_to_utf16_lenient(str_ptr, str.length(), &first_invalid_char);
+	if (first_invalid_char != nullptr) {
+		throw FileIOException("Invalid UTF-8 file name: [" + str + "]");
+	}
+	wchar_t *wide_ptr = reinterpret_cast<wchar_t *>(vec.data());
+	return std::wstring(wide_ptr, vec.size());
+}
+#endif // _WIN32
+
+bool FileExists(const std::string &path) {
+#ifdef _WIN32
+	std::wstring wpath = WidenStr(path);
+	DWORD attrs = GetFileAttributesW(wpath.c_str());
+	return (attrs != INVALID_FILE_ATTRIBUTES && !(attrs & FILE_ATTRIBUTE_DIRECTORY));
+#else  // !_WIN32
+	auto ret = access(path.c_str(), F_OK);
+	return ret != -1;
+#endif // _WIN32
+}
+
+std::size_t FileSizeBytes(const std::string &path) {
+#ifdef _WIN32
+	std::wstring wpath = WidenStr(path);
+	HANDLE file =
+	    CreateFileW(wpath.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if (file == INVALID_HANDLE_VALUE) {
+		throw FileIOException("Cannot open file, path: " + path);
+	}
+
+	LARGE_INTEGER size;
+	BOOL result = GetFileSizeEx(file, &size);
+	CloseHandle(file);
+
+	if (result == 0) {
+		throw FileIOException("Cannot get file size, path: " + path);
+	}
+	return size.QuadPart;
+#else  // !_WIN32
+	struct stat st;
+	auto ret = stat(path.c_str(), &st);
+	if (ret != 0) {
+		throw FileIOException("Cannot get file size, path: " + path);
+	}
+	return st.st_size;
+#endif // _WIN32
+}
+
+std::string FileReadToString(const std::string &path, std::size_t max_size_bytes) {
+	try {
+		std::ifstream file;
+		file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+
+#ifdef _WIN32
+		std::wstring wpath = WidenStr(path);
+		file.open(wpath, std::ios::in | std::ios::binary);
+#else  // !_WIN32
+		file.open(path, std::ios::in | std::ios::binary);
+#endif // _WIN32
+
+		std::string result;
+		result.resize(max_size_bytes);
+
+		std::size_t total_read = 0;
+		while (total_read < max_size_bytes && file) {
+			file.read(&result[total_read], max_size_bytes - total_read);
+			std::size_t bytes_read = file.gcount();
+			if (bytes_read == 0) {
+				break; // EOF
+			}
+			total_read += bytes_read;
+		}
+		result.resize(total_read);
+		return result;
+	} catch (const std::ios_base::failure &e) {
+		throw FileIOException("File read error, path: " + path + ", message: " + e.what());
+	}
+}
+
+} // namespace duckdb

--- a/src/common/odbc_utils.cpp
+++ b/src/common/odbc_utils.cpp
@@ -4,6 +4,7 @@
 
 #include <sql.h>
 
+#include <algorithm>
 #include <mutex>
 #include <regex>
 
@@ -455,4 +456,14 @@ int64_t duckdb::OdbcUtils::GetUTCOffsetMicrosFromOS(HSTMT hstmt_ptr, int64_t utc
 	return offset_seconds * 1000000;
 
 #endif // _WIN32
+}
+
+static bool IsSpace(char c) {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+std::string duckdb::OdbcUtils::TrimString(const std::string &str) {
+	auto front = std::find_if_not(str.begin(), str.end(), IsSpace);
+	auto back = std::find_if_not(str.rbegin(), str.rend(), IsSpace).base();
+	return (back <= front ? std::string() : std::string(front, back));
 }

--- a/src/connect/CMakeLists.txt
+++ b/src/connect/CMakeLists.txt
@@ -1,4 +1,5 @@
-add_library(odbc_connect OBJECT connect.cpp connection.cpp driver_connect.cpp)
+add_library(odbc_connect OBJECT connect.cpp connection.cpp driver_connect.cpp
+                                session_init.cpp)
 
 target_compile_definitions(odbc_connect PRIVATE -DDUCKDB_STATIC_BUILD)
 

--- a/src/connect/session_init.cpp
+++ b/src/connect/session_init.cpp
@@ -1,0 +1,139 @@
+#include "session_init.hpp"
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include "picosha2.h"
+
+#include "file_io.hpp"
+#include "handle_functions.hpp"
+
+namespace duckdb {
+
+const std::size_t SessionInitSQLFile::SQL_FILE_MAX_SIZE_BYTES = 1 << 20; // 1MB
+const std::string SessionInitSQLFile::CONN_INIT_MARKER = "/\\*\\s*DUCKDB_CONNECTION_INIT_BELOW_MARKER\\s*\\*/";
+
+static std::vector<std::string> SplitByMarker(const std::string &str) {
+	std::regex regex(SessionInitSQLFile::CONN_INIT_MARKER);
+	std::sregex_token_iterator first(str.begin(), str.end(), regex, -1);
+	std::sregex_token_iterator last;
+	return std::vector<std::string>(first, last);
+}
+
+SessionInitSQLFile::SessionInitSQLFile() {
+}
+
+SessionInitSQLFile::SessionInitSQLFile(std::string db_init_sql_in, std::string conn_init_sql_in,
+                                       std::string orig_file_text_in)
+    : db_init_sql(std::move(db_init_sql_in)), conn_init_sql(std::move(conn_init_sql_in)),
+      orig_file_text(std::move(orig_file_text_in)) {
+}
+
+bool SessionInitSQLFile::IsEmpty() {
+	return db_init_sql.empty() && conn_init_sql.empty() && orig_file_text.empty();
+}
+
+const std::string SessionInit::SQL_FILE_OPTION = "session_init_sql_file";
+const std::string SessionInit::SQL_FILE_SHA256_OPTION = "session_init_sql_file_sha256";
+
+SessionInitSQLFile SessionInit::ReadSQLFile(const std::string &session_init_sql_file,
+                                            const std::string &session_init_sql_file_sha256) {
+	if (session_init_sql_file.empty()) {
+		return SessionInitSQLFile();
+	}
+
+	if (!FileExists(session_init_sql_file)) {
+		throw FileIOException("Specified session init SQL file not found, path: " + session_init_sql_file);
+	}
+
+	std::size_t file_size = FileSizeBytes(session_init_sql_file);
+	if (file_size > SessionInitSQLFile::SQL_FILE_MAX_SIZE_BYTES) {
+		throw FileIOException(
+		    "Specified session init SQL file size: " + std::to_string(file_size) +
+		    " exceeds max allowed size: " + std::to_string(SessionInitSQLFile::SQL_FILE_MAX_SIZE_BYTES));
+	}
+
+	std::string orig_file_text = FileReadToString(session_init_sql_file, file_size);
+
+	if (!session_init_sql_file_sha256.empty()) {
+		std::string expected_sha256 = session_init_sql_file_sha256;
+		std::transform(expected_sha256.begin(), expected_sha256.end(), expected_sha256.begin(),
+		               [](char c) { return std::tolower(c); });
+		std::vector<unsigned char> digest(picosha2::k_digest_size);
+		picosha2::hash256(orig_file_text.begin(), orig_file_text.end(), digest.begin(), digest.end());
+		std::string actual_sha256 = picosha2::bytes_to_hex_string(digest.begin(), digest.end());
+		if (actual_sha256 != session_init_sql_file_sha256) {
+			throw FileIOException("Session init SQL file SHA-256 mismatch, expected: " + expected_sha256 +
+			                      ", actual: " + actual_sha256);
+		}
+	}
+
+	std::vector<std::string> parts = SplitByMarker(orig_file_text);
+	if (parts.size() > 2) {
+		throw FileIOException("Connection init marker: '" + SessionInitSQLFile::CONN_INIT_MARKER +
+		                      "' can only be specified once");
+	}
+
+	std::string db_init_sql = OdbcUtils::TrimString(parts.at(0));
+	std::string conn_init_sql = parts.size() == 2 ? OdbcUtils::TrimString(parts.at(1)) : std::string();
+
+	return SessionInitSQLFile(std::move(db_init_sql), std::move(conn_init_sql), std::move(orig_file_text));
+}
+
+static SQLRETURN RunQueryWithStmt(OdbcHandleDbc *dbc, const std::string &query) {
+	HSTMT hstmt = nullptr;
+
+	SQLRETURN alloc_ret = SQLAllocHandle(SQL_HANDLE_STMT, dbc, &hstmt);
+	if (!SQL_SUCCEEDED(alloc_ret)) {
+		return SetDiagnosticRecord(dbc, alloc_ret, "SQLDriverConnect",
+		                           "Connection init error: cannot allocate statement handle, SQL:\n" + query,
+		                           SQLStateType::ST_HY000, "");
+	}
+
+	SQLRETURN exec_ret = SQLExecDirect(hstmt, reinterpret_cast<SQLCHAR *>(const_cast<char *>(query.c_str())),
+	                                   static_cast<SQLSMALLINT>(query.length()));
+	if (!SQL_SUCCEEDED(exec_ret)) {
+		std::vector<SQLCHAR> sqlstate;
+		sqlstate.resize(6);
+		SQLINTEGER native_error;
+		std::vector<SQLCHAR> msg_buf;
+		msg_buf.resize(1024);
+		SQLSMALLINT msg_len;
+
+		SQLRETURN diag_ret = SQLGetDiagRec(SQL_HANDLE_STMT, hstmt, 1, sqlstate.data(), &native_error, msg_buf.data(),
+		                                   static_cast<SQLSMALLINT>(msg_buf.size()), &msg_len);
+		std::string message = "N/A";
+		if (SQL_SUCCEEDED(diag_ret)) {
+			message = std::string(reinterpret_cast<char *>(sqlstate.data()), sqlstate.size() - 1);
+			message += ": ";
+			message += std::string(reinterpret_cast<char *>(msg_buf.data()), static_cast<std::size_t>(msg_len));
+		}
+		SetDiagnosticRecord(dbc, exec_ret, "SQLDriverConnect", "Connection init error:\n" + message + "\n" + query,
+		                    SQLStateType::ST_42000, "");
+	}
+
+	SQLFreeStmt(hstmt, SQL_CLOSE);
+	SQLFreeHandle(SQL_HANDLE_STMT, hstmt);
+
+	return exec_ret;
+}
+
+SQLRETURN SessionInit::Run(OdbcHandleDbc *dbc, const SessionInitSQLFile &sql_file, bool db_created) {
+	if (db_created && !sql_file.db_init_sql.empty()) {
+		SQLRETURN ret = RunQueryWithStmt(dbc, sql_file.db_init_sql);
+		if (!SQL_SUCCEEDED(ret)) {
+			return ret;
+		}
+	}
+	if (!sql_file.conn_init_sql.empty()) {
+		SQLRETURN ret = RunQueryWithStmt(dbc, sql_file.conn_init_sql);
+		if (!SQL_SUCCEEDED(ret)) {
+			return ret;
+		}
+	}
+	return SetDiagnosticRecord(dbc, SQL_SUCCESS_WITH_INFO, "SQLDriverConnect",
+	                           "Session init SQL:\n" + sql_file.orig_file_text, SQLStateType::ST_01000, "");
+}
+
+} // namespace duckdb

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,12 +8,12 @@ add_executable(
   $<TARGET_OBJECTS:odbc_widechar>
   common.cpp
   connect_helpers.cpp
+  temp_directory.cpp
   tests/alter.cpp
   tests/basic_usage.cpp
   tests/bind_col.cpp
   tests/bools_as_char.cpp
   tests/catalog_functions.cpp
-  tests/connect.cpp
   tests/diagnostics.cpp
   tests/extension.cpp
   tests/select.cpp
@@ -29,7 +29,9 @@ add_executable(
   tests/test_empty_stubs.cpp
   tests/result_conversion.cpp
   tests/test_allowed_paths.cpp
+  tests/test_connect.cpp
   tests/test_long_data.cpp
+  tests/test_session_init.cpp
   tests/test_timestamp.cpp
   tests/test_unbound_params.cpp
   tests/test_widechar_conv.cpp

--- a/test/common.cpp
+++ b/test/common.cpp
@@ -1,7 +1,9 @@
 #define CATCH_CONFIG_MAIN
 #include "include/odbc_test_common.h"
 #include <cstring>
+#include <fstream>
 #include <vector>
+#include <odbcinst.h>
 #include "widechar.hpp"
 
 namespace odbc_test {
@@ -390,6 +392,26 @@ std::string GetTesterDirectory() {
 		return s;
 	}
 	return current_directory;
+}
+
+void WriteStringToFile(const std::string &file_path, const std::string &text) {
+	std::ofstream file;
+	file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+	file.open(file_path, std::ios::out | std::ios::binary);
+	file << text;
+	file.close();
+}
+
+UserOdbcIni::UserOdbcIni(std::vector<std::pair<std::string, std::string>> entries_in) : entries(std::move(entries_in)) {
+	for (auto &en : entries) {
+		SQLWritePrivateProfileString("DuckDB", en.first.c_str(), en.second.c_str(), "odbc.ini");
+	}
+}
+
+UserOdbcIni::~UserOdbcIni() {
+	for (auto &en : entries) {
+		SQLWritePrivateProfileString("DuckDB", en.first.c_str(), "", "odbc.ini");
+	}
 }
 
 } // namespace odbc_test

--- a/test/include/odbc_test_common.h
+++ b/test/include/odbc_test_common.h
@@ -4,6 +4,10 @@
 #include "catch.hpp"
 #include "odbc_utils.hpp"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -144,6 +148,19 @@ SQLPOINTER ConvertToSQLPOINTER(const char *str);
 std::string ConvertHexToString(SQLCHAR val[16], int precision);
 
 std::string GetTesterDirectory();
+
+void WriteStringToFile(const std::string &file_path, const std::string &text);
+
+class UserOdbcIni {
+	std::vector<std::pair<std::string, std::string>> entries;
+
+public:
+	UserOdbcIni(std::vector<std::pair<std::string, std::string>> entries_in);
+	~UserOdbcIni();
+
+	UserOdbcIni(const UserOdbcIni &) = delete;
+	UserOdbcIni &operator=(const UserOdbcIni &) = delete;
+};
 
 } // namespace odbc_test
 

--- a/test/include/temp_directory.hpp
+++ b/test/include/temp_directory.hpp
@@ -1,0 +1,29 @@
+#ifndef ODBC_TEST_TEMP_DIRECTORY_H
+#define ODBC_TEST_TEMP_DIRECTORY_H
+
+#include <string>
+
+namespace odbc_test {
+
+class TempDirectory {
+public:
+	std::string path;
+
+	static std::string get_temp_dir();
+
+	static std::string make_unique_dirname();
+
+	static void mkdir_check(const std::string &path);
+
+	static void remove_all(const std::string &path);
+
+	TempDirectory();
+	~TempDirectory();
+
+	TempDirectory(const TempDirectory &) = delete;
+	TempDirectory &operator=(const TempDirectory &) = delete;
+};
+
+} // namespace odbc_test
+
+#endif // ODBC_TEST_TEMP_DIRECTORY_H

--- a/test/temp_directory.cpp
+++ b/test/temp_directory.cpp
@@ -1,0 +1,138 @@
+#include "temp_directory.hpp"
+
+#include <cstdlib>
+#include <algorithm>
+#include <string>
+#include <random>
+#include <chrono>
+#include <stdexcept>
+#include <cstdio>
+#include <vector>
+#include <cerrno>
+
+#ifdef _WIN32
+#define VC_EXTRALEAN
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <direct.h>
+#define mkdir _mkdir
+#else
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace odbc_test {
+
+std::string TempDirectory::get_temp_dir() {
+#ifdef _WIN32
+	std::string res = ".";
+	char *tmp = std::getenv("TEMP");
+#else
+	std::string res = "/tmp";
+	char *tmp = std::getenv("TMPDIR");
+#endif
+	if (tmp != nullptr) {
+		res = std::string(tmp);
+	}
+	std::replace(res.begin(), res.end(), '\\', '/');
+	return res;
+}
+
+std::string TempDirectory::make_unique_dirname() {
+	auto now = std::chrono::system_clock::now().time_since_epoch().count();
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> dis(0, 100000);
+	return "tmpdir_duckdbtest_" + std::to_string(now) + "_" + std::to_string(dis(gen));
+}
+
+void TempDirectory::mkdir_check(const std::string &path) {
+#ifdef _WIN32
+	auto ret = mkdir(path.c_str());
+#else  // !_WiIN32
+	auto ret = mkdir(path.c_str(), 0755);
+#endif // _WIN32
+	if (ret != 0) {
+		throw std::runtime_error("Could not create temporary directory: " + path);
+	}
+}
+
+void TempDirectory::remove_all(const std::string &path) {
+#ifdef _WIN32
+	WIN32_FIND_DATA findFileData;
+	HANDLE hFind = INVALID_HANDLE_VALUE;
+
+	std::string pattern = path + "/*";
+	hFind = FindFirstFile(pattern.c_str(), &findFileData);
+
+	if (hFind == INVALID_HANDLE_VALUE) {
+		return;
+	}
+
+	do {
+		const char *name = findFileData.cFileName;
+		if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0) {
+			continue;
+		}
+
+		std::string fullpath = path + "/" + name;
+		if (findFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			remove_all(fullpath);
+		} else {
+			DeleteFile(fullpath.c_str());
+		}
+	} while (FindNextFile(hFind, &findFileData) != 0);
+	FindClose(hFind);
+	RemoveDirectory(path.c_str());
+#else
+	DIR *dir = opendir(path.c_str());
+	if (!dir) {
+		return;
+	}
+	struct dirent *entry;
+	while ((entry = readdir(dir)) != NULL) {
+		std::string name = entry->d_name;
+		if (name == "." || name == "..") {
+			continue;
+		}
+		std::string fullpath = path + "/" + name;
+		struct stat st;
+		if (stat(fullpath.c_str(), &st) == 0) {
+			if (S_ISDIR(st.st_mode)) {
+				remove_all(fullpath);
+			} else {
+				std::remove(fullpath.c_str());
+			}
+		}
+	}
+	closedir(dir);
+	rmdir(path.c_str());
+#endif
+}
+
+TempDirectory::TempDirectory() {
+	std::string base = get_temp_dir();
+	int max_tries = 16;
+	for (int i = 0; i < max_tries; ++i) {
+		std::string candidate = base + "/" + make_unique_dirname();
+		try {
+			mkdir_check(candidate);
+			path = candidate;
+			return;
+		} catch (...) {
+			// Try again with a new name
+		}
+	}
+	throw std::runtime_error("Unable to create temporary directory");
+}
+
+TempDirectory::~TempDirectory() {
+	if (!path.empty()) {
+		remove_all(path);
+	}
+}
+
+} // namespace odbc_test

--- a/test/tests/basic_usage.cpp
+++ b/test/tests/basic_usage.cpp
@@ -18,9 +18,6 @@ TEST_CASE("Basic ODBC usage", "[odbc]") {
 	ret = SQLAllocHandle(SQL_HANDLE_DBC, env, &dbc);
 	ODBC_CHECK(ret, "SQLAllocHandle (DBC)", nullptr);
 
-	ret = SQLConnect(dbc, ConvertToSQLCHAR(dsn), SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS);
-	ODBC_CHECK(ret, "SQLConnect", nullptr);
-
 	ret = SQLConnectW(dbc, ConvertToSQLWCHARNTS(dsn).data(), SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS);
 	ODBC_CHECK(ret, "SQLConnectW", nullptr);
 

--- a/test/tests/test_connect.cpp
+++ b/test/tests/test_connect.cpp
@@ -167,6 +167,14 @@ static void TestSettingConfigs() {
 
 	// Test handling unsupported connection string options
 	SetConfig("unsupported_option_1=value_1;allow_unsigned_extensions=true;", "allow_unsigned_extensions", "true");
+
+	// Test mixed case
+	SetConfig("Allow_Unsigned_Extensions=True", "allow_unsigned_extensions", "true");
+	SetConfig("Allow_Unsigned_Extensions=False", "allow_unsigned_extensions", "false");
+
+	// Test options trimming
+	SetConfig("foo1=bar1;  allow_unsigned_extensions = true ;foo2=bar2;", "allow_unsigned_extensions", "true");
+	SetConfig("foo1=bar1;  allow_unsigned_extensions = false ;foo2=bar2;", "allow_unsigned_extensions", "false");
 }
 
 static void CheckWorkerThreads(SQLHANDLE dbc, std::size_t expected_threads_count) {

--- a/test/tests/test_session_init.cpp
+++ b/test/tests/test_session_init.cpp
@@ -1,0 +1,294 @@
+#include "odbc_test_common.h"
+
+#include "temp_directory.hpp"
+
+using namespace odbc_test;
+
+TEST_CASE("Test session init for DB only", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+	HSTMT hstmt = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, "CREATE TABLE tab1(col1 int);CREATE TABLE tab2(col2 int);");
+	UserOdbcIni odbc_ini({{"session_init_sql_file", path}});
+
+	CONNECT_TO_DATABASE(env, dbc);
+
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("DROP TABLE tab1"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("DROP TABLE tab2"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test session init for DB and connection", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+	HSTMT hstmt = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, R"(
+CREATE TABLE tab1(col1 int);
+ /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ 
+INSERT INTO tab1 VALUES(42);
+)");
+	UserOdbcIni odbc_ini({{"session_init_sql_file", path}});
+
+	CONNECT_TO_DATABASE(env, dbc);
+
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("SELECT * FROM tab1"), SQL_NTS);
+
+	int32_t fetched = -1;
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_SLONG, &fetched, sizeof(fetched), nullptr);
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test session init for connection only", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+	HSTMT hstmt = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, R"(
+ /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */
+CREATE TABLE tab1(col1 int);
+)");
+	UserOdbcIni odbc_ini({{"session_init_sql_file", path}});
+
+	CONNECT_TO_DATABASE(env, dbc);
+
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("DROP TABLE tab1"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test session init fail no file", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+	HSTMT hstmt = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	// Not writing the file
+	UserOdbcIni odbc_ini({{"session_init_sql_file", path}});
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR("DSN=DuckDB"), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_ERROR);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "IM003");
+	REQUIRE(message.find("Specified session init SQL file not found") != std::string::npos);
+
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE("Test session init SHA256", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+	HSTMT hstmt = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, "CREATE TABLE tab1(col1 int)");
+	UserOdbcIni odbc_ini(
+	    {{"session_init_sql_file", path},
+	     {"session_init_sql_file_sha256", "e916fc2bcab2e0fad8d8e94273b8c79ff576aafbca9941e06ab268d9176269ec"}});
+
+	CONNECT_TO_DATABASE(env, dbc);
+
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("DROP TABLE tab1"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test session init SHA256 fail", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, "CREATE TABLE tab1(col1 int)");
+	UserOdbcIni odbc_ini(
+	    {{"session_init_sql_file", path},
+	     {"session_init_sql_file_sha256", "FAIL_e916fc2bcab2e0fad8d8e94273b8c79ff576aafbca9941e06ab268d9176269ec"}});
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR("DSN=DuckDB"), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_ERROR);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "IM003");
+	REQUIRE(message.find("Session init SQL file SHA-256 mismatch") != std::string::npos);
+
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE("Test session init conn string prohibited", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, "CREATE TABLE tab1(col1 int)");
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	std::string conn_str =
+	    "driver={DuckDB Driver};session_init_sql_file=" + path +
+	    ";session_init_sql_file_sha256=e916fc2bcab2e0fad8d8e94273b8c79ff576aafbca9941e06ab268d9176269ec;";
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR(conn_str.c_str()), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_ERROR);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "01S09");
+	REQUIRE(message.find("Options 'session_init_sql_file' and 'session_init_sql_file_sha256' can only be specified in "
+	                     "DSN configuration in a file or registry") != std::string::npos);
+
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE("Test session init tracing", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	std::string init_text = "CREATE TABLE tab1(col1 int)";
+	WriteStringToFile(path, init_text);
+	UserOdbcIni odbc_ini({
+	    {"session_init_sql_file", path},
+	});
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR("DSN=DuckDB"), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_SUCCESS_WITH_INFO);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "01000");
+	REQUIRE(message == "ODBC_DuckDB->SQLDriverConnect\nSession init SQL:\nCREATE TABLE tab1(col1 int)");
+
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test session init invalid file", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, R"(
+CREATE TABLE tab1(col1 int);
+ /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ 
+INSERT INTO tab1 VALUES(42);
+ /* DUCKDB_CONNECTION_INIT_BELOW_MARKER   */ 
+INSERT INTO tab1 VALUES(43);
+)");
+	UserOdbcIni odbc_ini({
+	    {"session_init_sql_file", path},
+	});
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR("DSN=DuckDB"), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_ERROR);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "IM003");
+	REQUIRE(message.length() > 0);
+
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+}
+
+TEST_CASE("Test session init file with bad SQL", "[odbc]") {
+	SQLHANDLE env = nullptr;
+	SQLHANDLE dbc = nullptr;
+
+	TempDirectory tmpdir;
+	std::string path = tmpdir.path + "/session_init.sql";
+	WriteStringToFile(path, R"(
+CREATE TABLE tab1(col1 INT NOT NULL);
+INSERT INTO tab1 VALUES(NULL);
+)");
+	UserOdbcIni odbc_ini({
+	    {"session_init_sql_file", path},
+	});
+
+	EXECUTE_AND_CHECK("SQLAllocHandle", nullptr, SQLAllocHandle, SQL_HANDLE_ENV, nullptr, &env);
+	EXECUTE_AND_CHECK("SQLSetEnvAttr (SQL_ATTR_ODBC_VERSION ODBC3)", nullptr, SQLSetEnvAttr, env, SQL_ATTR_ODBC_VERSION,
+	                  ConvertToSQLPOINTER(SQL_OV_ODBC3), 0);
+	EXECUTE_AND_CHECK("SQLAllocHandle (DBC)", nullptr, SQLAllocHandle, SQL_HANDLE_DBC, env, &dbc);
+
+	auto ret = SQLDriverConnect(dbc, nullptr, ConvertToSQLCHAR("DSN=DuckDB"), SQL_NTS, nullptr, SQL_NTS, nullptr,
+	                            SQL_DRIVER_COMPLETE);
+	REQUIRE(ret == SQL_ERROR);
+
+	std::string state;
+	std::string message;
+	ACCESS_DIAGNOSTIC_WIDE(state, message, dbc, SQL_HANDLE_DBC);
+
+	REQUIRE(state == "42000");
+	REQUIRE(message.length() > 0);
+
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_ENV)", nullptr, SQLFreeHandle, SQL_HANDLE_ENV, env);
+	EXECUTE_AND_CHECK("SQLFreeHandle(SQL_HANDLE_DBC)", nullptr, SQLFreeHandle, SQL_HANDLE_DBC, dbc);
+}

--- a/third_party/picosha2.h
+++ b/third_party/picosha2.h
@@ -1,0 +1,388 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR \
+    1048576  //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <sstream>
+#include <vector>
+#include <fstream>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                          0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                          0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline word_t rotr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+    assert(first + 64 == last);
+    static_cast<void>(last);  // for avoiding unused-variable warning
+    word_t w[64];
+    std::fill(w, w + 64, word_t(0));
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) +
+                          w[i - 16]);
+    }
+
+    word_t a = *message_digest;
+    word_t b = *(message_digest + 1);
+    word_t c = *(message_digest + 2);
+    word_t d = *(message_digest + 3);
+    word_t e = *(message_digest + 4);
+    word_t f = *(message_digest + 5);
+    word_t g = *(message_digest + 6);
+    word_t h = *(message_digest + 7);
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+        word_t temp2 = bsig0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = mask_32bit(d + temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = mask_32bit(temp1 + temp2);
+    }
+    *message_digest += a;
+    *(message_digest + 1) += b;
+    *(message_digest + 2) += c;
+    *(message_digest + 3) += d;
+    *(message_digest + 4) += e;
+    *(message_digest + 5) += f;
+    *(message_digest + 6) += g;
+    *(message_digest + 7) += h;
+    for (std::size_t i = 0; i < 8; ++i) {
+        *(message_digest + i) = mask_32bit(*(message_digest + i));
+    }
+}
+
+}  // namespace detail
+
+template <typename InIter>
+void output_hex(InIter first, InIter last, std::ostream& os) {
+    os.setf(std::ios::hex, std::ios::basefield);
+    while (first != last) {
+        os.width(2);
+        os.fill('0');
+        os << static_cast<unsigned int>(*first);
+        ++first;
+    }
+    os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string& hex_str) {
+    std::ostringstream oss;
+    output_hex(first, last, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer& bytes, std::string& hex_str) {
+    bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter>
+std::string bytes_to_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    bytes_to_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+template <typename InContainer>
+std::string bytes_to_hex_string(const InContainer& bytes) {
+    std::string hex_str;
+    bytes_to_hex_string(bytes, hex_str);
+    return hex_str;
+}
+
+class hash256_one_by_one {
+   public:
+    hash256_one_by_one() { init(); }
+
+    void init() {
+        buffer_.clear();
+        std::fill(data_length_digits_, data_length_digits_ + 4, word_t(0));
+        std::copy(detail::initial_message_digest,
+                  detail::initial_message_digest + 8, h_);
+    }
+
+    template <typename RaIter>
+    void process(RaIter first, RaIter last) {
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+        std::copy(first, last, std::back_inserter(buffer_));
+        std::size_t i = 0;
+        for (; i + 64 <= buffer_.size(); i += 64) {
+            detail::hash256_block(h_, buffer_.begin() + i,
+                                  buffer_.begin() + i + 64);
+        }
+        buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+    }
+
+    void finish() {
+        byte_t temp[64];
+        std::fill(temp, temp + 64, byte_t(0));
+        std::size_t remains = buffer_.size();
+        std::copy(buffer_.begin(), buffer_.end(), temp);
+        assert(remains < 64);
+
+        // This branch is not executed actually (`remains` is always lower than 64),
+        // but needed to avoid g++ false-positive warning.
+        // See https://github.com/okdshin/PicoSHA2/issues/25
+        // vvvvvvvvvvvvvvvv
+        if(remains >= 64) {
+            remains = 63;
+        }
+        // ^^^^^^^^^^^^^^^^
+
+        temp[remains] = 0x80;
+
+        if (remains > 55) {
+            std::fill(temp + remains + 1, temp + 64, byte_t(0));
+            detail::hash256_block(h_, temp, temp + 64);
+            std::fill(temp, temp + 64 - 4, byte_t(0));
+        } else {
+            std::fill(temp + remains + 1, temp + 64 - 4, byte_t(0));
+        }
+
+        write_data_bit_length(&(temp[56]));
+        detail::hash256_block(h_, temp, temp + 64);
+    }
+
+    template <typename OutIter>
+    void get_hash_bytes(OutIter first, OutIter last) const {
+        for (const word_t* iter = h_; iter != h_ + 8; ++iter) {
+            for (std::size_t i = 0; i < 4 && first != last; ++i) {
+                *(first++) = detail::mask_8bit(
+                    static_cast<byte_t>((*iter >> (24 - 8 * i))));
+            }
+        }
+    }
+
+   private:
+    void add_to_data_length(word_t n) {
+        word_t carry = 0;
+        data_length_digits_[0] += n;
+        for (std::size_t i = 0; i < 4; ++i) {
+            data_length_digits_[i] += carry;
+            if (data_length_digits_[i] >= 65536u) {
+                carry = data_length_digits_[i] >> 16;
+                data_length_digits_[i] &= 65535u;
+            } else {
+                break;
+            }
+        }
+    }
+    void write_data_bit_length(byte_t* begin) {
+        word_t data_bit_length_digits[4];
+        std::copy(data_length_digits_, data_length_digits_ + 4,
+                  data_bit_length_digits);
+
+        // convert byte length to bit length (multiply 8 or shift 3 times left)
+        word_t carry = 0;
+        for (std::size_t i = 0; i < 4; ++i) {
+            word_t before_val = data_bit_length_digits[i];
+            data_bit_length_digits[i] <<= 3;
+            data_bit_length_digits[i] |= carry;
+            data_bit_length_digits[i] &= 65535u;
+            carry = (before_val >> (16 - 3)) & 65535u;
+        }
+
+        // write data_bit_length
+        for (int i = 3; i >= 0; --i) {
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+        }
+    }
+    std::vector<byte_t> buffer_;
+    word_t data_length_digits_[4];  // as 64bit integer (16bit x 4 integer)
+    word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one& hasher,
+                                std::string& hex_str) {
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
+    std::string hex_str;
+    get_hash_hex_string(hasher, hex_str);
+    return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+    hash256_one_by_one hasher;
+    // hasher.init();
+    hasher.process(first, last);
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2,
+                  OutIter last2, int buffer_size, std::input_iterator_tag) {
+    std::vector<byte_t> buffer(buffer_size);
+    hash256_one_by_one hasher;
+    // hasher.init();
+    while (first != last) {
+        int size = buffer_size;
+        for (int i = 0; i != buffer_size; ++i, ++first) {
+            if (first == last) {
+                size = i;
+                break;
+            }
+            buffer[i] = *first;
+        }
+        hasher.process(buffer.begin(), buffer.begin() + size);
+    }
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+}
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+    picosha2::impl::hash256_impl(
+        first, last, first2, last2, buffer_size,
+        typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer& dst) {
+    hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer& src, OutIter first, OutIter last) {
+    hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer& src, OutContainer& dst) {
+    hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
+    std::ostringstream oss;
+    output_hex(hashed, hashed + k_digest_size, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InIter>
+std::string hash256_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    hash256_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+inline void hash256_hex_string(const std::string& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+std::string hash256_hex_string(const InContainer& src) {
+    return hash256_hex_string(src.begin(), src.end());
+}
+template<typename OutIter>void hash256(std::ifstream& f, OutIter first, OutIter last){
+    hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first,last);
+
+}
+}// namespace picosha2
+#endif  // PICOSHA2_H


### PR DESCRIPTION
This is a backport of the PR #157 to `v1.3-ossivalis` stable branch.

This change is a counterpart of a similar functionality in DuckDB JDBC driver added in duckdb/duckdb-java#252.

It adds support for `session_init_sql_file` connection option, that allows to speficy the path to an SQL file in local file system, that will be read by the driver and executed in a newly created connection before passing it to user.

By default the file is initalized only once per database, on the first `SQLConnect` call to this DB.

For `:memory:` connection-private DBs it effectively executed once per connection.

In addition to the DB init, it supports executing a part of the SQL file for every connection. It looks for the specific marker:

```
/* DUCKDB_CONNECTION_INIT_BELOW_MARKER */
```

in the SQL file. If this marker is present - everything before the marker is executed on DB init, and everything after this marker - on connection init.

To minimize the security impact of this change in contexts, where other applications/processes/users can control the appending to user-specified connection string or re-writing the specified file in local file system, the following restrictions are added:

 - `session_init_sql_file` can only be specified in the DSN configuration in `.ini` file or in Windows Registry; unlike oridinary options, this options can NOT be used in the connection string to override DSN configuration
 - `session_init_sql_file_sha256=<sha56sum_of_sql_file>` option can be specified (also only in DSN), the file contents SHA-256 sum is checked againts this value
 - contents of the SQL file being executed are added to the diagnostic records for the `SQLConnect/SQLDriverConnect` call, when ODBC tracing is enabled in Driver Manager settings - the full SQL file is printed to the log like this:

```
<Client app name>       7cc-2300	EXIT  SQLDriverConnectW  with return code 1 (SQL_SUCCESS_WITH_INFO)
[...]
DIAG [01000] ODBC_DuckDB->SQLDriverConnect
Session init SQL:
<SQL file contents>
```

Testing: new tests added (in a separate file), they use `SQLWritePrivateProfileString` Driver Manager API to temporary set `session_init_sql_file` in user DSN settings. This call has some limitations (cannot set `database` on Windows) but is confirmed to work on CI for all platforms.