### PR TITLE
Support running with older C++ stdlib

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -190,6 +190,15 @@ jobs:
         run: |
           ./build/release/bin/Release/test_odbc.exe
 
+      - name: Test Standard ODBC tests with VS2019 C++ stdlib
+        if: ${{ inputs.skip_tests != 'true' }}
+        shell: bash
+        run: |
+          choco install wget -y --no-progress
+          wget -P build/release/bin/Release https://blobs.duckdb.org/ci/msvcp140.dll
+          ./build/release/bin/Release/test_odbc.exe
+          rm build/release/bin/Release/msvcp140.dll
+
       - name: Test PyODBC
         if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
@@ -243,8 +252,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          choco install zip -y --force
-          zip -j duckdb_odbc-windows-amd64.zip                \
+          /c/msys64/usr/bin/bash.exe -lc "pacman -Sy --noconfirm zip"
+          /c/msys64/usr/bin/zip.exe -j duckdb_odbc-windows-amd64.zip \
             ./build/release/bin/Release/duckdb_odbc.dll       \
             ./build/release/bin/Release/duckdb_odbc_setup.dll \
             ./build/release/bin/Release/odbc_install.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_compile_definitions(duckdb_core_obj PRIVATE
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT )
 if(WIN32)
   target_compile_options(duckdb_core_obj PRIVATE /bigobj)
+  target_compile_definitions(duckdb_core_obj PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_core_obj>)
@@ -79,6 +80,7 @@ add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES})
 target_compile_definitions(duckdb_odbc PRIVATE -DDUCKDB_STATIC_BUILD)
 if(WIN32)
   target_compile_options(duckdb_odbc PRIVATE /bigobj)
+  target_compile_definitions(duckdb_odbc PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -66,6 +66,7 @@ target_compile_definitions(duckdb_core_obj PRIVATE
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT )
 if(WIN32)
   target_compile_options(duckdb_core_obj PRIVATE /bigobj)
+  target_compile_definitions(duckdb_core_obj PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_core_obj>)
@@ -79,6 +80,7 @@ add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES})
 target_compile_definitions(duckdb_odbc PRIVATE -DDUCKDB_STATIC_BUILD)
 if(WIN32)
   target_compile_options(duckdb_odbc PRIVATE /bigobj)
+  target_compile_definitions(duckdb_odbc PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,11 @@ add_library(
 
 target_compile_definitions(odbc_src PRIVATE -DDUCKDB_STATIC_BUILD)
 
+if(WIN32)
+  target_compile_definitions(odbc_src
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_src>
     PARENT_SCOPE)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -10,6 +10,11 @@ add_library(
 
 target_compile_definitions(odbc_common PRIVATE -DDUCKDB_STATIC_BUILD)
 
+if(WIN32)
+  target_compile_definitions(odbc_common
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_common>
     PARENT_SCOPE)

--- a/src/connect/CMakeLists.txt
+++ b/src/connect/CMakeLists.txt
@@ -3,6 +3,11 @@ add_library(odbc_connect OBJECT connect.cpp connection.cpp driver_connect.cpp
 
 target_compile_definitions(odbc_connect PRIVATE -DDUCKDB_STATIC_BUILD)
 
+if(WIN32)
+  target_compile_definitions(odbc_connect
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_connect>
     PARENT_SCOPE)

--- a/src/statement/CMakeLists.txt
+++ b/src/statement/CMakeLists.txt
@@ -2,6 +2,11 @@ add_library(odbc_statement OBJECT statement.cpp statement_functions.cpp)
 
 target_compile_definitions(odbc_statement PRIVATE -DDUCKDB_STATIC_BUILD)
 
+if(WIN32)
+  target_compile_definitions(odbc_statement
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_statement>
     PARENT_SCOPE)

--- a/src/widechar/CMakeLists.txt
+++ b/src/widechar/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_library(odbc_widechar OBJECT widechar.cpp)
 
+if(WIN32)
+  target_compile_definitions(odbc_widechar
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+endif()
+
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_widechar>
     PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,11 @@ add_executable(
 
 if(WIN32)
   target_compile_options(test_odbc PRIVATE /bigobj)
+  target_compile_definitions(test_odbc
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
   target_compile_options(test_connection_odbc PRIVATE /bigobj)
+  target_compile_definitions(test_connection_odbc
+                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")


### PR DESCRIPTION
This change adds `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` flag for Windows builds that prevents crashes when the host process, into which the ODBC driver is loaded, is run using older versions of C++ stdlib.

Details: duckdb/duckdb#17991

Testing: additional test run added that uses `msvcp140.dll` from VS2019 instead of the system-provided one.