### PR TITLE
Fix SQL_NUMERIC_STRUCT handling for neg decs (1.3)

### DIFF
--- a/src/parameter_descriptor.cpp
+++ b/src/parameter_descriptor.cpp
@@ -344,12 +344,20 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 			return SQL_ERROR;
 		}
 		if (precision <= Decimal::MAX_WIDTH_INT64) {
-			value =
-			    Value::DECIMAL(Load<int64_t>(dataptr), static_cast<uint8_t>(precision), static_cast<uint8_t>(scale));
+			int64_t dec_val = Load<int64_t>(dataptr);
+			// Handle sign: 0 = negative, 1 = positive
+			if (numeric->sign == 0) {
+				dec_val = -dec_val;
+			}
+			value = Value::DECIMAL(dec_val, static_cast<uint8_t>(precision), static_cast<uint8_t>(scale));
 		} else {
 			hugeint_t dec_value;
 			memcpy(&dec_value.lower, dataptr, sizeof(dec_value.lower));
 			memcpy(&dec_value.upper, dataptr + sizeof(dec_value.lower), sizeof(dec_value.upper));
+			// Handle sign: 0 = negative, 1 = positive
+			if (numeric->sign == 0) {
+				dec_value = -dec_value;
+			}
 			value = Value::DECIMAL(dec_value, static_cast<uint8_t>(precision), static_cast<uint8_t>(scale));
 		}
 		break;

--- a/src/statement/statement_functions.cpp
+++ b/src/statement/statement_functions.cpp
@@ -511,7 +511,7 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 
 			string str_fraction = str_val.substr(pos_dot);
 			// case all digits in fraction is 0, remove them
-			if (std::stoi(str_fraction) == 0) {
+			if (!str_fraction.empty() && str_fraction.find_first_not_of('0') == string::npos) {
 				str_val.erase(str_val.begin() + pos_dot, str_val.end());
 			}
 			width = str_val.size();
@@ -527,10 +527,9 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 			memcpy(dataptr, &val_i64, sizeof(val_i64));
 		} else {
 			hugeint_t huge_int;
-			string error_message;
-			CastParameters parameters(false, &error_message);
-			if (!duckdb::TryCastToDecimal::Operation<string_t, hugeint_t>(str_t, huge_int, parameters,
-			                                                              numeric->precision, numeric->scale)) {
+			// The string has already been processed to remove decimal point, so it's an integer string
+			// We need to convert it directly to hugeint_t
+			if (!duckdb::TryCast::Operation(str_t, huge_int)) {
 				return SQL_ERROR;
 			}
 			memcpy(dataptr, &huge_int.lower, sizeof(huge_int.lower));


### PR DESCRIPTION
This is a backport of the PR #172 to `v1.3-ossivalis` stable branch.

  - Handle sign field (0=negative, 1=positive) when binding SQL_NUMERIC_STRUCT parameters
  - Fix SQLGetData conversion of large decimals by using TryCast instead of TryCastToDecimal
  - Add exception handling for std::stoi to prevent overflow with large decimal fractions
  - Add tests for negative decimals in both parameter binding and result retrieval