### PR TITLE
Update vendored DuckDB sources to 2efc9ec537

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "3-dev130"
+#define DUCKDB_PATCH_VERSION "3-dev133"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 3
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.3.3-dev130"
+#define DUCKDB_VERSION "v1.3.3-dev133"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "4f243e8c1f"
+#define DUCKDB_SOURCE_ID "2efc9ec537"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#2efc9ec537](https://github.com/duckdb/duckdb/commit/2efc9ec537) imported at 2025-07-30 05:41:14
