### PR TITLE
Update vendored DuckDB sources to 5766d00d2b

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "3-dev144"
+#define DUCKDB_PATCH_VERSION "3-dev147"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 3
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.3.3-dev144"
+#define DUCKDB_VERSION "v1.3.3-dev147"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "67cbce34e1"
+#define DUCKDB_SOURCE_ID "5766d00d2b"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#5766d00d2b](https://github.com/duckdb/duckdb/commit/5766d00d2b) imported at 2025-08-07 06:18:10
