### PR TITLE
Revert GCC 12 downgrade for Linux builds

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -42,9 +42,7 @@ jobs:
             cat /etc/os-release
             dnf install -y   \
               unixODBC-devel \
-              ninja-build    \
-              gcc-toolset-12-gcc-c++
-            source /opt/rh/gcc-toolset-12/enable
+              ninja-build
             make -C /duckdb release
           "
 
@@ -101,9 +99,7 @@ jobs:
             cat /etc/os-release
             dnf install -y   \
               unixODBC-devel \
-              ninja-build    \
-              gcc-toolset-12-gcc-c++
-            source /opt/rh/gcc-toolset-12/enable
+              ninja-build
             make -C /duckdb release
           "
 


### PR DESCRIPTION
This change revert the usage of `gcc-toolset-12` for `x86_64` and `aarch64` Linux builds. See duckdb/duckdb#17963 for details.