### PR TITLE
Revert "Revert GCC 12 downgrade for Linux builds"

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -42,7 +42,9 @@ jobs:
             cat /etc/os-release
             dnf install -y   \
               unixODBC-devel \
-              ninja-build
+              ninja-build    \
+              gcc-toolset-12-gcc-c++
+            source /opt/rh/gcc-toolset-12/enable
             make -C /duckdb release
           "
 
@@ -99,7 +101,9 @@ jobs:
             cat /etc/os-release
             dnf install -y   \
               unixODBC-devel \
-              ninja-build
+              ninja-build    \
+              gcc-toolset-12-gcc-c++
+            source /opt/rh/gcc-toolset-12/enable
             make -C /duckdb release
           "
 


### PR DESCRIPTION
This reverts commit 88d5abcecb606a430c0f584b3c7993dbe5ea788a.

See details in duckdb/duckdb#17963.