### PR TITLE
Fix exported symbols on Mac (1.4)

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -48,6 +48,10 @@ jobs:
             make -C /duckdb release
           "
 
+      - name: List Symbols
+        run: |
+          nm -gU ./build/release/libduckdb_odbc.so
+
       - name: ODBC Tests
         shell: bash
         if: ${{ inputs.skip_tests != 'true' }}
@@ -107,6 +111,10 @@ jobs:
             make -C /duckdb release
           "
 
+      - name: List Symbols
+        run: |
+          nm -gU ./build/release/libduckdb_odbc.so
+
       - name: ODBC Tests
         shell: bash
         if: ${{ inputs.skip_tests != 'true' }}
@@ -165,6 +173,12 @@ jobs:
       - name: Build
         shell: bash
         run: make release
+
+      - name: List Symbols
+        shell: cmd
+        run: |
+          call "c:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          dumpbin.exe /exports build\release\bin\Release\duckdb_odbc.dll
 
       - name: Setup ODBC
         shell: bash
@@ -275,13 +289,16 @@ jobs:
       OSX_BUILD_UNIVERSAL: 1
     needs: odbc-linux-amd64
     steps:
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.git_ref }}
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         with:
@@ -291,16 +308,24 @@ jobs:
       - name: Install UnixODBC
         shell: bash
         run: CFLAGS="-arch x86_64 -arch arm64" ./scripts/install_unixodbc.sh
+
       - name: Build
         shell: bash
         run: make release
+
+      - name: List Symbols
+        run: |
+          nm -gU ./build/release/libduckdb_odbc.dylib
+
       - name: ODBC Tests
         if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
         run: ./build/release/test/test_odbc
+
       - name: See if this actually universal
         shell: bash
         run: lipo -archs build/release/libduckdb_odbc.dylib | grep "x86_64 arm64"
+
       - name: Deploy
         shell: bash
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if(NOT WIN32)
       -Bsymbolic-functions
       -fvisibility=hidden
       -Wl,--version-script=${CMAKE_CURRENT_LIST_DIR}/duckdb_odbc.map)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_link_options(duckdb_odbc PRIVATE
       -fvisibility=hidden
       -Wl,-exported_symbols_list,${CMAKE_CURRENT_LIST_DIR}/duckdb_odbc.exp)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -93,7 +93,7 @@ if(NOT WIN32)
       -Bsymbolic-functions
       -fvisibility=hidden
       -Wl,--version-script=${CMAKE_CURRENT_LIST_DIR}/duckdb_odbc.map)
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     target_link_options(duckdb_odbc PRIVATE
       -fvisibility=hidden
       -Wl,-exported_symbols_list,${CMAKE_CURRENT_LIST_DIR}/duckdb_odbc.exp)

--- a/duckdb_odbc.def
+++ b/duckdb_odbc.def
@@ -520,7 +520,6 @@ SQLBrowseConnectW
 SQLBulkOperations
 SQLCancel
 SQLCloseCursor
-SQLCloseCursor
 SQLColAttribute
 SQLColAttributeW
 SQLColAttributes

--- a/duckdb_odbc.exp
+++ b/duckdb_odbc.exp
@@ -516,7 +516,6 @@ _SQLBrowseConnectW
 _SQLBulkOperations
 _SQLCancel
 _SQLCloseCursor
-_SQLCloseCursor
 _SQLColAttribute
 _SQLColAttributeW
 _SQLColAttributes

--- a/duckdb_odbc.map
+++ b/duckdb_odbc.map
@@ -518,7 +518,6 @@ DUCKDB_ODBC {
     SQLBulkOperations;
     SQLCancel;
     SQLCloseCursor;
-    SQLCloseCursor;
     SQLColAttribute;
     SQLColAttributeW;
     SQLColAttributes;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -34,22 +34,24 @@ SQLRETURN SQL_API SQLSetCursorNameW(SQLHSTMT statement_handle, SQLWCHAR *cursor_
 	                                   duckdb::SQLStateType::ST_IM001, hstmt->dbc->GetDataSourceName());
 }
 
-SQLRETURN SQL_API SQLGetCursorName(SQLHSTMT statement_handle, SQLCHAR *cursor_name, SQLSMALLINT name_length) {
+SQLRETURN SQL_API SQLGetCursorName(SQLHSTMT statement_handle, SQLCHAR *cursor_name, SQLSMALLINT name_length,
+                                   SQLSMALLINT *length_ptr) {
 	duckdb::OdbcHandleStmt *hstmt = nullptr;
 	SQLRETURN ret = ConvertHSTMT(statement_handle, hstmt);
 	if (ret != SQL_SUCCESS) {
 		return ret;
 	}
-	return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetCursorName", "SQLGetCursorName is not supported.",
+	return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLGetCursorName", "SQLGetCursorName is not supported.",
 	                                   duckdb::SQLStateType::ST_IM001, hstmt->dbc->GetDataSourceName());
 }
 
-SQLRETURN SQL_API SQLGetCursorNameW(SQLHSTMT statement_handle, SQLWCHAR *cursor_name, SQLSMALLINT name_length) {
+SQLRETURN SQL_API SQLGetCursorNameW(SQLHSTMT statement_handle, SQLWCHAR *cursor_name, SQLSMALLINT name_length,
+                                    SQLSMALLINT *length_ptr) {
 	duckdb::OdbcHandleStmt *hstmt = nullptr;
 	SQLRETURN ret = ConvertHSTMT(statement_handle, hstmt);
 	if (ret != SQL_SUCCESS) {
 		return ret;
 	}
-	return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLSetCursorNameW", "SQLGetCursorNameW is not supported.",
+	return duckdb::SetDiagnosticRecord(hstmt, SQL_ERROR, "SQLGetCursorNameW", "SQLGetCursorNameW is not supported.",
 	                                   duckdb::SQLStateType::ST_IM001, hstmt->dbc->GetDataSourceName());
 }


### PR DESCRIPTION
This is a backport of the PR #232 to `v1.4-andium` stable branch.

This PR is a follow-up to #82 change, it fixes the exported symbols for MacOS and adds listing of symbols on CI runs.