### PR TITLE
Update vendored DuckDB sources to b8a06e4a22

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-dev4124"
+#define DUCKDB_PATCH_VERSION "0"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,7 +8,7 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.0-dev4124"
+#define DUCKDB_VERSION "v1.4.0"
 #endif
 #ifndef DUCKDB_SOURCE_ID
 #define DUCKDB_SOURCE_ID "b8a06e4a22"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#b8a06e4a22](https://github.com/duckdb/duckdb/commit/b8a06e4a22) imported at 2025-09-16 19:31:09
