### PR TITLE
Fix SQLNumResultCols for CALL, EXECUTE (1.4)

### DIFF
--- a/src/prepared.cpp
+++ b/src/prepared.cpp
@@ -77,7 +77,13 @@ SQLRETURN SQL_API SQLNumResultCols(SQLHSTMT statement_handle, SQLSMALLINT *colum
 	}
 	*column_count_ptr = (SQLSMALLINT)hstmt->stmt->ColumnCount();
 
-	if (hstmt->stmt->data->statement_type != duckdb::StatementType::SELECT_STATEMENT) {
+	switch (hstmt->stmt->data->statement_type) {
+	case duckdb::StatementType::CALL_STATEMENT:
+	case duckdb::StatementType::EXECUTE_STATEMENT:
+	case duckdb::StatementType::EXPLAIN_STATEMENT:
+	case duckdb::StatementType::SELECT_STATEMENT:
+		break;
+	default:
 		*column_count_ptr = 0;
 	}
 	return SQL_SUCCESS;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   tests/test_allowed_paths.cpp
   tests/test_connect.cpp
   tests/test_long_data.cpp
+  tests/test_num_result_cols.cpp
   tests/test_session_init.cpp
   tests/test_timestamp.cpp
   tests/test_unbound_params.cpp

--- a/test/tests/test_num_result_cols.cpp
+++ b/test/tests/test_num_result_cols.cpp
@@ -1,0 +1,76 @@
+#include "odbc_test_common.h"
+
+using namespace odbc_test;
+
+TEST_CASE("Test EXPLAIN output", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	CONNECT_TO_DATABASE(env, dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("EXPLAIN SELECT 42"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQLSMALLINT cols = 0;
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &cols);
+	REQUIRE(cols == 2);
+	DATA_CHECK(hstmt, 1, "physical_plan");
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test CALL output", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	CONNECT_TO_DATABASE(env, dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("CREATE MACRO hello() AS TABLE SELECT 'Hello' AS column1, 'World' AS column2"),
+	                  SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("CALL hello()"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQLSMALLINT cols = 0;
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &cols);
+	REQUIRE(cols == 2);
+	DATA_CHECK(hstmt, 1, "Hello");
+	DATA_CHECK(hstmt, 2, "World");
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}
+
+TEST_CASE("Test EXECUTE output", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	CONNECT_TO_DATABASE(env, dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("PREPARE p AS SELECT 'Hello' AS column1, 'World' AS column2"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt, ConvertToSQLCHAR("EXECUTE p"), SQL_NTS);
+
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQLSMALLINT cols = 0;
+	EXECUTE_AND_CHECK("SQLNumResultCols", hstmt, SQLNumResultCols, hstmt, &cols);
+	REQUIRE(cols == 2);
+	DATA_CHECK(hstmt, 1, "Hello");
+	DATA_CHECK(hstmt, 2, "World");
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}


### PR DESCRIPTION
This is a backport of the PR #241 to `v1.4-andium` stable branch.

This PR fixes the `SQLNumResultCols` function making it to return the actual number of columns for `CALL`, `EXECUTE` and `EXPLAIN` queries. Without that some ODBC clients were unable to fetch the result set for such queries.

`EXPLAIN` output contains 1 row with 2 columns. First column is a constant `physical_plan` (or `logical_plan`) and the second column contains actual plan details as a `VARCHAR`.

Testing: new test added.

Fixes: #200