### PR TITLE
Update vendored DuckDB sources to b3c8acdc0e

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-dev720"
+#define DUCKDB_PATCH_VERSION "0-dev722"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 5
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.5.0-dev720"
+#define DUCKDB_VERSION "v1.5.0-dev722"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "5657cbdc0b"
+#define DUCKDB_SOURCE_ID "b3c8acdc0e"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#b3c8acdc0e](https://github.com/duckdb/duckdb/commit/b3c8acdc0e) imported at 2025-10-07 03:30:35
