### PR TITLE
Update vendored DuckDB sources to cdf9e7c1e8

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "1-dev195"
+#define DUCKDB_PATCH_VERSION "1-dev197"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.1-dev195"
+#define DUCKDB_VERSION "v1.4.1-dev197"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "b390a7c376"
+#define DUCKDB_SOURCE_ID "cdf9e7c1e8"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#cdf9e7c1e8](https://github.com/duckdb/duckdb/commit/cdf9e7c1e8) imported at 2025-10-07 05:02:50
