### PR TITLE
Link MSVC runtime library statically

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -247,6 +247,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          dumpbin.exe /imports build\release\bin\duckdb_odbc.dll
           dumpbin.exe /exports build\release\bin\duckdb_odbc.dll
 
       - name: Setup ODBC
@@ -403,6 +404,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsarm64.bat"
+          dumpbin.exe /imports build\release\bin\duckdb_odbc.dll
           dumpbin.exe /exports build\release\bin\duckdb_odbc.dll
 
       - name: Setup ODBC
@@ -427,7 +429,7 @@ jobs:
         if: ${{ inputs.skip_tests != 'true' }}
         shell: bash
         run: |
-          ./build/release/bin/test_odbc.exe || true
+          ./build/release/bin/test_odbc.exe
 
       - name: Test PyODBC
         if: ${{ inputs.skip_tests != 'true' }}
@@ -478,7 +480,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.S3_DUCKDB_STAGING_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_DUCKDB_STAGING_KEY }}
         run: |
-          choco install zip -y --force
           zip -j duckdb_odbc-windows-arm64.zip        \
             ./build/release/bin/duckdb_odbc.dll       \
             ./build/release/bin/duckdb_odbc_setup.dll \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 
-project(duckdb-odbc)
+project(duckdb-odbc C CXX)
+
 find_package(ODBC)
 find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(NOT ODBC_FOUND)
   message(FATAL_ERROR "No ODBC found; you need to install unixodbc-dev.")
@@ -66,7 +68,6 @@ target_compile_definitions(duckdb_core_obj PRIVATE
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT )
 if(WIN32)
   target_compile_options(duckdb_core_obj PRIVATE /bigobj)
-  target_compile_definitions(duckdb_core_obj PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_core_obj>)
@@ -80,7 +81,6 @@ add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES})
 target_compile_definitions(duckdb_odbc PRIVATE -DDUCKDB_STATIC_BUILD)
 if(WIN32)
   target_compile_options(duckdb_odbc PRIVATE /bigobj)
-  target_compile_definitions(duckdb_odbc PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,12 +1,14 @@
-cmake_minimum_required(VERSION 3.12.0)
+cmake_minimum_required(VERSION 3.5...3.29)
 
-project(duckdb-odbc)
+project(duckdb-odbc C CXX)
+
 find_package(ODBC)
 find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_STANDARD "11" CACHE STRING "C++ standard to enforce")
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 if(NOT ODBC_FOUND)
   message(FATAL_ERROR "No ODBC found; you need to install unixodbc-dev.")
@@ -66,7 +68,6 @@ target_compile_definitions(duckdb_core_obj PRIVATE
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT )
 if(WIN32)
   target_compile_options(duckdb_core_obj PRIVATE /bigobj)
-  target_compile_definitions(duckdb_core_obj PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_core_obj>)
@@ -80,7 +81,6 @@ add_library(duckdb_odbc SHARED ${ALL_OBJECT_FILES})
 target_compile_definitions(duckdb_odbc PRIVATE -DDUCKDB_STATIC_BUILD)
 if(WIN32)
   target_compile_options(duckdb_odbc PRIVATE /bigobj)
-  target_compile_definitions(duckdb_odbc PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 set_target_properties(duckdb_odbc PROPERTIES DEFINE_SYMBOL "DUCKDB_ODBC_API")

--- a/src/odbc_api/CMakeLists.txt
+++ b/src/odbc_api/CMakeLists.txt
@@ -18,11 +18,6 @@ add_library(
 
 target_compile_definitions(odbc_api PRIVATE -DDUCKDB_STATIC_BUILD)
 
-if(WIN32)
-  target_compile_definitions(odbc_api
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_api>
     PARENT_SCOPE)

--- a/src/odbc_driver/CMakeLists.txt
+++ b/src/odbc_driver/CMakeLists.txt
@@ -8,11 +8,6 @@ add_library(odbc_driver OBJECT driver.cpp api_info.cpp descriptor.cpp
 
 target_compile_definitions(odbc_driver PRIVATE -DDUCKDB_STATIC_BUILD)
 
-if(WIN32)
-  target_compile_definitions(odbc_driver
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_driver>
     PARENT_SCOPE)

--- a/src/odbc_driver/common/CMakeLists.txt
+++ b/src/odbc_driver/common/CMakeLists.txt
@@ -10,11 +10,6 @@ add_library(
 
 target_compile_definitions(odbc_common PRIVATE -DDUCKDB_STATIC_BUILD)
 
-if(WIN32)
-  target_compile_definitions(odbc_common
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_common>
     PARENT_SCOPE)

--- a/src/odbc_driver/connect/CMakeLists.txt
+++ b/src/odbc_driver/connect/CMakeLists.txt
@@ -2,11 +2,6 @@ add_library(odbc_connect OBJECT connect.cpp session_init.cpp)
 
 target_compile_definitions(odbc_connect PRIVATE -DDUCKDB_STATIC_BUILD)
 
-if(WIN32)
-  target_compile_definitions(odbc_connect
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_connect>
     PARENT_SCOPE)

--- a/src/odbc_driver/statement/CMakeLists.txt
+++ b/src/odbc_driver/statement/CMakeLists.txt
@@ -2,11 +2,6 @@ add_library(odbc_statement OBJECT statement_functions.cpp)
 
 target_compile_definitions(odbc_statement PRIVATE -DDUCKDB_STATIC_BUILD)
 
-if(WIN32)
-  target_compile_definitions(odbc_statement
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_statement>
     PARENT_SCOPE)

--- a/src/odbc_driver/widechar/CMakeLists.txt
+++ b/src/odbc_driver/widechar/CMakeLists.txt
@@ -1,10 +1,5 @@
 add_library(odbc_widechar OBJECT widechar.cpp)
 
-if(WIN32)
-  target_compile_definitions(odbc_widechar
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
-endif()
-
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:odbc_widechar>
     PARENT_SCOPE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -54,11 +54,7 @@ add_executable(
 
 if(WIN32)
   target_compile_options(test_odbc PRIVATE /bigobj)
-  target_compile_definitions(test_odbc
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
   target_compile_options(test_connection_odbc PRIVATE /bigobj)
-  target_compile_definitions(test_connection_odbc
-                             PRIVATE -D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 endif()
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio")

--- a/test/tests/dotnet/CMakeLists.txt
+++ b/test/tests/dotnet/CMakeLists.txt
@@ -24,3 +24,5 @@ list(APPEND VS_DOTNET_REFERENCES "System.Xml.Linq")
 
 set_target_properties(${PROJECT_NAME} PROPERTIES VS_DOTNET_REFERENCES
                                                  "${VS_DOTNET_REFERENCES}")
+
+target_compile_options(${PROJECT_NAME} PRIVATE /MD)


### PR DESCRIPTION
This change makes all CMake targets to use `-MT`/`-MTd` compilation flags for Windows MSVC builds. This way the MSVC runtime library is linked statically and the workaround for VS2019 added in #169 is no longer necessary.

`extension-ci-tools` PR: duckdb/extension-ci-tools#276

Ref: duckdblabs/duckdb-internal#2036