### PR TITLE
Update vendored DuckDB sources to b4d86dddcf

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "2-dev142"
+#define DUCKDB_PATCH_VERSION "2-dev146"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.2-dev142"
+#define DUCKDB_VERSION "v1.4.2-dev146"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "8d3a195080"
+#define DUCKDB_SOURCE_ID "b4d86dddcf"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#b4d86dddcf](https://github.com/duckdb/duckdb/commit/b4d86dddcf) imported at 2025-10-28 04:40:23
