### PR TITLE
Fix NumResultsCol for extension statements

### DIFF
--- a/src/odbc_api/column_info_api.cpp
+++ b/src/odbc_api/column_info_api.cpp
@@ -345,6 +345,7 @@ SQLRETURN SQL_API SQLNumResultCols(SQLHSTMT statement_handle, SQLSMALLINT *colum
 	case duckdb::StatementType::CALL_STATEMENT:
 	case duckdb::StatementType::EXECUTE_STATEMENT:
 	case duckdb::StatementType::EXPLAIN_STATEMENT:
+	case duckdb::StatementType::EXTENSION_STATEMENT:
 	case duckdb::StatementType::SELECT_STATEMENT:
 		break;
 	default:


### PR DESCRIPTION
This change allows the statements of type `EXTENSION_STATEMENT` to return results.

Testing: there seems to be no easy way to cover this with the test suite as we don't want to depend on more extensions than now in tests. Checked manually with `duckpgq`.

Fixes: #200