### PR TITLE
Fix NumResultsCol for extension statements (1.4)

### DIFF
--- a/src/prepared.cpp
+++ b/src/prepared.cpp
@@ -81,6 +81,7 @@ SQLRETURN SQL_API SQLNumResultCols(SQLHSTMT statement_handle, SQLSMALLINT *colum
 	case duckdb::StatementType::CALL_STATEMENT:
 	case duckdb::StatementType::EXECUTE_STATEMENT:
 	case duckdb::StatementType::EXPLAIN_STATEMENT:
+	case duckdb::StatementType::EXTENSION_STATEMENT:
 	case duckdb::StatementType::SELECT_STATEMENT:
 		break;
 	default:


### PR DESCRIPTION
This is a backport of the PR #300 to `v1.4-andium` stable branch.

This change allows the statements of type `EXTENSION_STATEMENT` to return results.

Testing: there seems to be no easy way to cover this with the test suite as we don't want to depend on more extensions than now in tests. Checked manually with `duckpgq`.

Fixes: #200