### PR TITLE
Update vendored DuckDB sources to 1c03ec0812

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "4-dev14"
+#define DUCKDB_PATCH_VERSION "4-dev17"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.4-dev14"
+#define DUCKDB_VERSION "v1.4.4-dev17"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "200198b3e0"
+#define DUCKDB_SOURCE_ID "1c03ec0812"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"

--- a/src/duckdb/src/include/duckdb/common/http_util.hpp
+++ b/src/duckdb/src/include/duckdb/common/http_util.hpp
@@ -139,7 +139,7 @@ struct BaseRequest {
 	const string &url;
 	string path;
 	string proto_host_port;
-	const HTTPHeaders &headers;
+	HTTPHeaders headers;
 	HTTPParams &params;
 	//! Whether or not to return failed requests (instead of throwing)
 	bool try_request = false;
@@ -156,6 +156,14 @@ struct BaseRequest {
 	template <class TARGET>
 	const TARGET &Cast() const {
 		return reinterpret_cast<const TARGET &>(*this);
+	}
+
+	static HTTPHeaders MergeHeaders(const HTTPHeaders &headers, HTTPParams &params) {
+		HTTPHeaders result = headers;
+		for (const auto &header : params.extra_headers) {
+			result.Insert(header.first, header.second);
+		}
+		return result;
 	}
 };
 

--- a/src/duckdb/src/main/http/http_util.cpp
+++ b/src/duckdb/src/main/http/http_util.cpp
@@ -123,7 +123,7 @@ unique_ptr<HTTPResponse> HTTPUtil::Request(BaseRequest &request, unique_ptr<HTTP
 }
 
 BaseRequest::BaseRequest(RequestType type, const string &url, const HTTPHeaders &headers, HTTPParams &params)
-    : type(type), url(url), headers(headers), params(params) {
+    : type(type), url(url), headers(MergeHeaders(headers, params)), params(params) {
 	HTTPUtil::DecomposeURL(url, path, proto_host_port);
 }
 
@@ -189,9 +189,6 @@ private:
 	duckdb_httplib::Headers TransformHeaders(const HTTPHeaders &header_map, const HTTPParams &params) {
 		duckdb_httplib::Headers headers;
 		for (auto &entry : header_map) {
-			headers.insert(entry);
-		}
-		for (auto &entry : params.extra_headers) {
 			headers.insert(entry);
 		}
 		return headers;


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#1c03ec0812](https://github.com/duckdb/duckdb/commit/1c03ec0812) imported at 2025-12-12 06:11:41
