### PR TITLE
Switch Linux toolchain to GCC 14

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -59,10 +59,8 @@ jobs:
             cat /etc/os-release
             dnf install -y           \
               ccache                 \
-              gcc-toolset-12-gcc-c++ \
               ninja-build            \
               unixODBC-devel
-            source /opt/rh/gcc-toolset-12/enable
             make -C /duckdb release
           "
 
@@ -148,10 +146,8 @@ jobs:
             cat /etc/os-release
             dnf install -y           \
               ccache                 \
-              gcc-toolset-12-gcc-c++ \
               ninja-build            \
               unixODBC-devel
-            source /opt/rh/gcc-toolset-12/enable
             make -C /duckdb release
           "
 


### PR DESCRIPTION
This change removes the usage of the GCC 12 (from devtoolset) to stay in line with the main DuckDB that made this switch in duckdb/duckdb#20170.