### PR TITLE
Use macos-latest on CI

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -503,7 +503,7 @@ jobs:
 
   odbc-osx-universal:
     name: macOS (Universal)
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       GEN: ninja
       CC: 'ccache clang'


### PR DESCRIPTION
Following the same change in the engine: duckdb/duckdb#20169