### PR TITLE
Update vendored DuckDB sources to 43a67ee2be

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "0-dev5016"
+#define DUCKDB_PATCH_VERSION "0-dev5019"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 5
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.5.0-dev5016"
+#define DUCKDB_VERSION "v1.5.0-dev5019"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "b5761ca54c"
+#define DUCKDB_SOURCE_ID "43a67ee2be"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#43a67ee2be](https://github.com/duckdb/duckdb/commit/43a67ee2be) imported at 2025-12-24 05:44:23
