### PR TITLE
Update vendored DuckDB sources to e4c85765ee

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "5-dev79"
+#define DUCKDB_PATCH_VERSION "5-dev81"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.5-dev79"
+#define DUCKDB_VERSION "v1.4.5-dev81"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "a8d8e49b32"
+#define DUCKDB_SOURCE_ID "e4c85765ee"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#e4c85765ee](https://github.com/duckdb/duckdb/commit/e4c85765ee) imported at 2026-06-04 06:34:42
