### PR TITLE
Update vendored DuckDB sources to 123e696a93

### DIFF
--- a/src/duckdb/src/function/table/version/pragma_version.cpp
+++ b/src/duckdb/src/function/table/version/pragma_version.cpp
@@ -1,5 +1,5 @@
 #ifndef DUCKDB_PATCH_VERSION
-#define DUCKDB_PATCH_VERSION "5-dev83"
+#define DUCKDB_PATCH_VERSION "5-dev85"
 #endif
 #ifndef DUCKDB_MINOR_VERSION
 #define DUCKDB_MINOR_VERSION 4
@@ -8,10 +8,10 @@
 #define DUCKDB_MAJOR_VERSION 1
 #endif
 #ifndef DUCKDB_VERSION
-#define DUCKDB_VERSION "v1.4.5-dev83"
+#define DUCKDB_VERSION "v1.4.5-dev85"
 #endif
 #ifndef DUCKDB_SOURCE_ID
-#define DUCKDB_SOURCE_ID "01cf2e8119"
+#define DUCKDB_SOURCE_ID "123e696a93"
 #endif
 #include "duckdb/function/table/system_functions.hpp"
 #include "duckdb/main/database.hpp"

--- a/src/duckdb/src/storage/storage_info.cpp
+++ b/src/duckdb/src/storage/storage_info.cpp
@@ -87,6 +87,7 @@ static const StorageVersionInfo storage_version_info[] = {
 	{"v1.4.2", 67},
 	{"v1.4.3", 67},
 	{"v1.4.4", 67},
+	{"v1.4.5", 67},
 	{nullptr, 0}
 };
 // END OF STORAGE VERSION INFO
@@ -116,6 +117,7 @@ static const SerializationVersionInfo serialization_version_info[] = {
 	{"v1.4.2", 6},
 	{"v1.4.3", 6},
 	{"v1.4.4", 6},
+	{"v1.4.5", 6},
 	{"latest", 6},
 	{nullptr, 0}
 };


### PR DESCRIPTION
Changes:
 - [duckdb/duckdb#123e696a93](https://github.com/duckdb/duckdb/commit/123e696a93) imported at 2026-06-06 05:56:55
