### PR TITLE
Enable jemalloc allocator (main)

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -14,6 +14,23 @@ if(NOT ODBC_FOUND)
   message(FATAL_ERROR "No ODBC found; you need to install unixodbc-dev.")
 endif()
 
+# variables set by vendor.py
+
+set(DUCKDB_INCLUDE_DIRS
+  ${INCLUDES})
+
+set(JEMALLOC_INCLUDE_DIRS
+  ${JEMALLOC_INCLUDES})
+
+set(DUCKDB_DEFINITIONS
+  ${DEFINES})
+
+set(DUCKDB_SRC_FILES 
+  ${SOURCES})
+
+set(JEMALLOC_SRC_FILES 
+  ${JEMALLOC_SOURCES})
+
 set(LINK_LIB_LIST "")
 
 if(ODBC_FOUND)
@@ -53,13 +70,16 @@ if(OSX_BUILD_UNIVERSAL)
   SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for Mac OS X" FORCE)
 endif()
 
-add_definitions(-DDUCKDB_BUILD_LIBRARY -DNO_FRAMEWORKS ${DEFINES})
+add_definitions(-DDUCKDB_BUILD_LIBRARY -DNO_FRAMEWORKS ${DUCKDB_DEFINITIONS})
 
-include_directories(src/duckdb/src/include/ ${INCLUDE_FILES} ${ODBC_INCLUDE_DIRS} include third_party)
+include_directories(src/duckdb/src/include/ ${DUCKDB_INCLUDE_DIRS} ${ODBC_INCLUDE_DIRS} include third_party)
 
 add_subdirectory(src)
 
-set(CORE_OBJECT_FILES ${SOURCE_FILES})
+set(CORE_OBJECT_FILES ${DUCKDB_SRC_FILES})
+if(NOT WIN32)
+  list(APPEND CORE_OBJECT_FILES ${JEMALLOC_SRC_FILES})
+endif()
 
 add_library(duckdb_core_obj OBJECT ${CORE_OBJECT_FILES})
 target_compile_definitions(duckdb_core_obj PRIVATE 
@@ -68,6 +88,9 @@ target_compile_definitions(duckdb_core_obj PRIVATE
   -DDUCKDB_EXTENSION_AUTOINSTALL_DEFAULT )
 if(WIN32)
   target_compile_options(duckdb_core_obj PRIVATE /bigobj)
+else()
+  target_compile_options(duckdb_core_obj PRIVATE -DDUCKDB_ENABLE_JEMALLOC)
+  target_include_directories(duckdb_core_obj PRIVATE ${JEMALLOC_INCLUDE_DIRS})
 endif()
 
 set(ALL_OBJECT_FILES ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:duckdb_core_obj>)

--- a/vendor.py
+++ b/vendor.py
@@ -2,17 +2,18 @@ import os
 import sys
 import json
 import pickle
+import platform
 import argparse
+
+def sanitize_path(x):
+    return x.replace('\\', '/')
 
 parser = argparse.ArgumentParser(description='Inlines DuckDB Sources')
 
 parser.add_argument('--duckdb', action='store',
                     help='Path to the DuckDB Version to be vendored in', required=True, type=str)
 
-
-
 args = parser.parse_args()
-
 
 # list of extensions to bundle
 extensions = ['core_functions', 'parquet', 'icu', 'json']
@@ -30,53 +31,44 @@ import package_build
 
 defines = ['DUCKDB_EXTENSION_{}_LINKED'.format(ext.upper()) for ext in extensions]
 
-# # Autoloading is on by default for node distributions
-# defines.extend(['DUCKDB_EXTENSION_AUTOLOAD_DEFAULT=1', 'DUCKDB_EXTENSION_AUTOINSTALL_DEFAULT=1'])
-
-
-
-
-
-
 # fresh build - copy over all of the files
 (source_list, include_list, original_sources) = package_build.build_package(target_dir, extensions, False)
-
-
-
-# # # the list of all source files (.cpp files) that have been copied into the `duckdb_source_copy` directory
-# # print(source_list)
-# # # the list of all include files
-# # print(include_list)
-source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x) for x in source_list]
-include_list = [os.path.join('src', 'duckdb', x) for x in include_list]
-
-libraries = []
-
-def sanitize_path(x):
-    return x.replace('\\', '/')
-
-
 source_list = [sanitize_path(x) for x in source_list]
 include_list = [sanitize_path(x) for x in include_list]
-libraries = [sanitize_path(x) for x in libraries]
+
+# process jemalloc separately with its own CMake vars
+jemalloc_source_list = [x for x in source_list if x.startswith("duckdb/third_party/jemalloc/")]
+jemalloc_include_list = [x for x in include_list if x.startswith("third_party/jemalloc/")]
+
+# clean up paths
+source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x)
+    for x in source_list if x not in jemalloc_source_list]
+source_list = [x.replace("/./", "/") for x in source_list]
+jemalloc_source_list = [os.path.relpath(x, basedir) if os.path.isabs(x) else os.path.join('src', x)
+    for x in jemalloc_source_list]
+jemalloc_source_list = [x for x in jemalloc_source_list if not x.endswith("jemalloc_cpp.cpp")]
+include_list = [os.path.join('src', 'duckdb', x) for x in include_list if x not in jemalloc_include_list]
+jemalloc_include_list = [os.path.join('src', 'duckdb', x) for x in jemalloc_include_list]
+
+# sort paths
+source_list.sort()
+jemalloc_source_list.sort()
+include_list.sort()
+jemalloc_include_list.sort()
 
 os.chdir(basedir)
 
 with open('CMakeLists.txt.in', 'r') as f:
     cmake = f.read()
 
-
 def replace_entries(cmake, replacement_map):
     cmake.replace()
 
-
-cmake = cmake.replace('${SOURCE_FILES}', ' '.join(source_list))
-cmake = cmake.replace('${INCLUDE_FILES}', ' '.join(include_list))
-cmake = cmake.replace('${DEFINES}', ' '.join(['-D'+x for x in defines]))
-cmake = cmake.replace('${LIBRARY_FILES}', ' '.join(libraries))
-# cmake.replace('${CFLAGS}', cflags)
-# cmake.replace('${WINDOWS_OPTIONS}', windows_options)
-
+cmake = cmake.replace('${SOURCES}', '\n  '.join(source_list))
+cmake = cmake.replace('${JEMALLOC_SOURCES}', '\n  '.join(jemalloc_source_list))
+cmake = cmake.replace('${INCLUDES}', '\n  '.join(include_list))
+cmake = cmake.replace('${JEMALLOC_INCLUDES}', '\n  '.join(jemalloc_include_list))
+cmake = cmake.replace('${DEFINES}', '\n  '.join(['-D'+x for x in defines]))
 
 with open('CMakeLists.txt', 'w+') as f:
     f.write(cmake)


### PR DESCRIPTION
This is a forward port of the PR #444 to the `main` branch.

This PR enables `jemalloc` allocator for Linux and macOS builds bringing ODBC in line with other clients that use `jemalloc`.

Ref: duckdb/duckdb#22558