### PR TITLE
Fix fraction handling in SQL_C_TYPE_TIMESTAMP

### DIFF
--- a/src/odbc_driver/parameter_descriptor.cpp
+++ b/src/odbc_driver/parameter_descriptor.cpp
@@ -364,8 +364,9 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	}
 	case SQL_TYPE_TIMESTAMP: {
 		auto timestamp_struct = Load<SQL_TIMESTAMP_STRUCT>(dataptr);
-		value = Value::TIMESTAMP(timestamp_struct.year, timestamp_struct.month, timestamp_struct.day,
-		                         timestamp_struct.hour, timestamp_struct.minute, timestamp_struct.second, 0);
+		value =
+		    Value::TIMESTAMP(timestamp_struct.year, timestamp_struct.month, timestamp_struct.day, timestamp_struct.hour,
+		                     timestamp_struct.minute, timestamp_struct.second, timestamp_struct.fraction / 1000);
 		break;
 	}
 	case SQL_TYPE_DATE: {

--- a/src/odbc_driver/statement/statement_functions.cpp
+++ b/src/odbc_driver/statement/statement_functions.cpp
@@ -734,7 +734,7 @@ SQLRETURN duckdb::GetDataStmtResult(OdbcHandleStmt *hstmt, SQLUSMALLINT col_or_p
 		timestamp_struct->hour = hour;
 		timestamp_struct->minute = minute;
 		timestamp_struct->second = second;
-		timestamp_struct->fraction = micros;
+		timestamp_struct->fraction = micros * 1000;
 		if (str_len_or_ind_ptr) {
 			*str_len_or_ind_ptr = sizeof(SQL_TIMESTAMP_STRUCT);
 		}

--- a/test/tests/dotnet-linux/Program.cs
+++ b/test/tests/dotnet-linux/Program.cs
@@ -59,12 +59,20 @@ class Program
         CheckFileldType(conn, "SELECT ''::VARCHAR", "System.String");
     }
 
-    static void ExecuteReaderOdbcCommand(OdbcConnection conn, string sql)
+    static void ExecuteNonQueryOdbcCommand(OdbcConnection conn, string sql)
     {
-        // Console.WriteLine(sql);
         using (var cmd = new OdbcCommand(sql, conn))
         {
-            using (OdbcDataReader reader = cmd.ExecuteReader()) {
+            cmd.ExecuteNonQuery();
+        }
+    }
+
+    static void ExecuteReaderOdbcCommand(OdbcConnection conn, string sql)
+    {
+        using (var cmd = new OdbcCommand(sql, conn))
+        {
+            using (OdbcDataReader reader = cmd.ExecuteReader())
+            {
                 while (reader.Read()) {
                     object a = reader[0];
                 }
@@ -82,6 +90,24 @@ class Program
         ExecuteReaderOdbcCommand(conn, "COMMIT;");
     }
 
+    static void TestTimestampNanos(OdbcConnection conn)
+    {
+        ExecuteNonQueryOdbcCommand(conn, "CREATE OR REPLACE TABLE dotnet_timestamp_test(col1 TIMESTAMP)");
+        ExecuteNonQueryOdbcCommand(conn, "INSERT INTO dotnet_timestamp_test VALUES('2000-01-01 12:10:30.123456'::TIMESTAMP)");
+        using (var cmd = new OdbcCommand("FROM dotnet_timestamp_test", conn))
+        {
+            using (OdbcDataReader reader = cmd.ExecuteReader())
+            {
+                while (reader.Read()) {
+                    DateTime timestamp = reader.GetDateTime(0);
+                    AssertEquals("123", timestamp.Millisecond.ToString());
+                    AssertEquals("456", timestamp.Microsecond.ToString());
+                }
+            }
+        }
+        ExecuteNonQueryOdbcCommand(conn, "DROP TABLE dotnet_timestamp_test");
+    }
+
     static void Main(string[] args)
     {
         using (OdbcConnection conn = new OdbcConnection("Driver={DuckDB Driver}"))
@@ -89,6 +115,7 @@ class Program
             conn.Open();
             TestFieldTypes(conn);
             TestPrepareExecuteColAtrributeReader(conn);
+            TestTimestampNanos(conn);
         }
 
         Console.WriteLine("dotnet-linux tests passed successfully");

--- a/test/tests/test_timestamp.cpp
+++ b/test/tests/test_timestamp.cpp
@@ -22,12 +22,34 @@ TEST_CASE("Test SQLBindParameter with TIMESTAMP type", "[odbc]") {
 
 	// Create table
 	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("CREATE TABLE timestamp_bind_test (col1 TIMESTAMP)"), SQL_NTS);
+	                  ConvertToSQLCHAR("CREATE TABLE timestamp_bind_test (col1 INT, col2 TIMESTAMP)"), SQL_NTS);
 
-	// Insert value
+	// Insert literal value
+	EXECUTE_AND_CHECK(
+	    "SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	    ConvertToSQLCHAR("INSERT INTO timestamp_bind_test VALUES(41, '2000-01-01 12:10:30.123456'::TIMESTAMP)"),
+	    SQL_NTS);
+	// Fetch and check
+	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("SELECT col2 FROM timestamp_bind_test WHERE col1 = 41"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	{
+		SQL_TIMESTAMP_STRUCT fetched;
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_TYPE_TIMESTAMP, &fetched, sizeof(fetched),
+		                  nullptr);
+		REQUIRE(fetched.year == 2000);
+		REQUIRE(fetched.month == 1);
+		REQUIRE(fetched.day == 1);
+		REQUIRE(fetched.hour == 12);
+		REQUIRE(fetched.minute == 10);
+		REQUIRE(fetched.second == 30);
+		REQUIRE(fetched.fraction == 123456000);
+	}
+
+	// Insert parametrized value
 	EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
-	                  ConvertToSQLCHAR("INSERT INTO timestamp_bind_test VALUES (?)"), SQL_NTS);
-	SQL_TIMESTAMP_STRUCT param = {2000, 1, 1, 12, 10, 30, 0};
+	                  ConvertToSQLCHAR("INSERT INTO timestamp_bind_test VALUES (42, ?)"), SQL_NTS);
+	SQL_TIMESTAMP_STRUCT param = {2000, 2, 2, 12, 10, 30, 123456789};
 	SQLLEN param_len = sizeof(param);
 	EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP,
 	                  SQL_TYPE_TIMESTAMP, 0, 0, &param, param_len, &param_len);
@@ -35,18 +57,20 @@ TEST_CASE("Test SQLBindParameter with TIMESTAMP type", "[odbc]") {
 
 	// Fetch and check
 	EXECUTE_AND_CHECK("SQLExecDirect", hstmt, SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("SELECT * FROM timestamp_bind_test"), SQL_NTS);
+	                  ConvertToSQLCHAR("SELECT col2 FROM timestamp_bind_test WHERE col1 = 42"), SQL_NTS);
 	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
-	SQL_TIMESTAMP_STRUCT fetched;
-	EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_TYPE_TIMESTAMP, &fetched, sizeof(fetched),
-	                  nullptr);
-	REQUIRE(fetched.year == param.year);
-	REQUIRE(fetched.month == param.month);
-	REQUIRE(fetched.day == param.day);
-	REQUIRE(fetched.hour == param.hour);
-	REQUIRE(fetched.minute == param.minute);
-	REQUIRE(fetched.second == param.second);
-	REQUIRE(fetched.fraction == param.fraction);
+	{
+		SQL_TIMESTAMP_STRUCT fetched;
+		EXECUTE_AND_CHECK("SQLGetData", hstmt, SQLGetData, hstmt, 1, SQL_C_TYPE_TIMESTAMP, &fetched, sizeof(fetched),
+		                  nullptr);
+		REQUIRE(fetched.year == param.year);
+		REQUIRE(fetched.month == param.month);
+		REQUIRE(fetched.day == param.day);
+		REQUIRE(fetched.hour == param.hour);
+		REQUIRE(fetched.minute == param.minute);
+		REQUIRE(fetched.second == param.second);
+		REQUIRE(fetched.fraction == 123456000);
+	}
 
 	// Free the statement handle
 	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);


### PR DESCRIPTION
This PR fixes the following problems with timestamps:

1. fractional part (nanosecond) was ignored in prepared inserts with parameters of type `TIMESTAMP_STRUCT`

2. fractional part was returned as microseconds instead of nanoseconds

Testing: C++ and .NET test coverage is added for timestamp fractions.

Fixes: #446