### PR TITLE
Fix: read string parameters by the application C type, not the target SQL type

### DIFF
--- a/src/odbc_driver/parameter_descriptor.cpp
+++ b/src/odbc_driver/parameter_descriptor.cpp
@@ -293,19 +293,6 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	case SQL_WLONGVARCHAR: {
 		auto buff_size = duckdb::MaxValue((SQLLEN)ipd->records[rec_idx].sql_desc_length,
 		                                  apd->records[rec_idx].sql_desc_octet_length);
-		// Mirror of the char branch: a client may bind SQL_C_CHAR (narrow, 1 byte/char)
-		// data against a wide SQL_WVARCHAR parameter. Reading that buffer as UTF-16 yields
-		// garbage and can over-read past the end (the UTF-16 NUL scan runs off the buffer).
-		// Decode it as narrow based on the C type.
-		if (apd_record->sql_desc_type == SQL_C_CHAR) {
-			auto str_data = (char *)sql_data_ptr + (val_idx * buff_size);
-			if (*sql_ind_ptr_val_set == SQL_NTS) {
-				*sql_ind_ptr_val_set = strlen(str_data);
-			}
-			auto str_len = *sql_ind_ptr_val_set;
-			value = Value(duckdb::OdbcUtils::ConvertSQLCHARToString(reinterpret_cast<SQLCHAR *>(str_data), str_len));
-			break;
-		}
 		auto utf16_data = (SQLWCHAR *)sql_data_ptr + (val_idx * buff_size);
 		if (*sql_ind_ptr_val_set == SQL_NTS) {
 			*sql_ind_ptr_val_set = static_cast<SQLLEN>(duckdb::widechar::utf16_length(utf16_data) * sizeof(SQLWCHAR));

--- a/src/odbc_driver/parameter_descriptor.cpp
+++ b/src/odbc_driver/parameter_descriptor.cpp
@@ -267,6 +267,19 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	case SQL_LONGVARCHAR: {
 		auto buff_size = duckdb::MaxValue((SQLLEN)ipd->records[rec_idx].sql_desc_length,
 		                                  apd->records[rec_idx].sql_desc_octet_length);
+		// Clients such as Power BI / .NET System.Data.Odbc bind SQL_C_WCHAR (UTF-16)
+		// data against a narrow SQL_VARCHAR parameter - Decode it as UTF-16 based on
+		// the C type instead, following the SQL_WCHAR case below.
+		if (apd_record->sql_desc_type == SQL_C_WCHAR) {
+			auto utf16_data = (SQLWCHAR *)sql_data_ptr + (val_idx * buff_size);
+			if (*sql_ind_ptr_val_set == SQL_NTS) {
+				*sql_ind_ptr_val_set = static_cast<SQLLEN>(duckdb::widechar::utf16_length(utf16_data) * sizeof(SQLWCHAR));
+			}
+			auto utf16_len = static_cast<size_t>(*sql_ind_ptr_val_set / sizeof(SQLWCHAR));
+			auto utf8_vec = duckdb::widechar::utf16_to_utf8_lenient(utf16_data, utf16_len);
+			value = Value(std::string(reinterpret_cast<char *>(utf8_vec.data()), utf8_vec.size()));
+			break;
+		}
 		auto str_data = (char *)sql_data_ptr + (val_idx * buff_size);
 		if (*sql_ind_ptr_val_set == SQL_NTS) {
 			*sql_ind_ptr_val_set = strlen(str_data);
@@ -280,6 +293,19 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	case SQL_WLONGVARCHAR: {
 		auto buff_size = duckdb::MaxValue((SQLLEN)ipd->records[rec_idx].sql_desc_length,
 		                                  apd->records[rec_idx].sql_desc_octet_length);
+		// Mirror of the char branch: a client may bind SQL_C_CHAR (narrow, 1 byte/char)
+		// data against a wide SQL_WVARCHAR parameter. Reading that buffer as UTF-16 yields
+		// garbage and can over-read past the end (the UTF-16 NUL scan runs off the buffer).
+		// Decode it as narrow based on the C type.
+		if (apd_record->sql_desc_type == SQL_C_CHAR) {
+			auto str_data = (char *)sql_data_ptr + (val_idx * buff_size);
+			if (*sql_ind_ptr_val_set == SQL_NTS) {
+				*sql_ind_ptr_val_set = strlen(str_data);
+			}
+			auto str_len = *sql_ind_ptr_val_set;
+			value = Value(duckdb::OdbcUtils::ConvertSQLCHARToString(reinterpret_cast<SQLCHAR *>(str_data), str_len));
+			break;
+		}
 		auto utf16_data = (SQLWCHAR *)sql_data_ptr + (val_idx * buff_size);
 		if (*sql_ind_ptr_val_set == SQL_NTS) {
 			*sql_ind_ptr_val_set = static_cast<SQLLEN>(duckdb::widechar::utf16_length(utf16_data) * sizeof(SQLWCHAR));

--- a/test/tests/test_widechar_data.cpp
+++ b/test/tests/test_widechar_data.cpp
@@ -70,12 +70,6 @@ static SQLBIGINT FetchCount(HSTMT hstmt) {
 	return count;
 }
 
-// Regression: the driver must read a bound parameter buffer according to the
-// application C type (APD), not the target SQL type (IPD). Power BI / .NET
-// System.Data.Odbc bind SQL_C_WCHAR (UTF-16) data against a narrow SQL_VARCHAR
-// parameter; before the fix it was read as narrow ("N\0o\0r\0t\0h"), so
-// `WHERE region = ?` matched nothing. The mirror case (SQL_C_CHAR against a wide
-// SQL_WVARCHAR parameter) read a narrow buffer as UTF-16 -> garbage + over-read.
 TEST_CASE("Test SQLBindParameter with mismatched C and SQL types", "[odbc]") {
 	SQLHANDLE env;
 	SQLHANDLE dbc;
@@ -95,17 +89,6 @@ TEST_CASE("Test SQLBindParameter with mismatched C and SQL types", "[odbc]") {
 		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE region = ?"), SQL_NTS);
 		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
 		                  SQL_VARCHAR, north_utf16.size(), 0, north_utf16.data(), ind, &ind);
-		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
-		REQUIRE(FetchCount(hstmt) == 1);
-	}
-
-	SECTION("SQL_C_CHAR buffer bound as SQL_WVARCHAR") {
-		SQLCHAR north_utf8[] = "North";
-		SQLLEN ind = 5;
-		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
-		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE region = ?"), SQL_NTS);
-		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
-		                  SQL_WVARCHAR, 5, 0, north_utf8, ind, &ind);
 		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 		REQUIRE(FetchCount(hstmt) == 1);
 	}

--- a/test/tests/test_widechar_data.cpp
+++ b/test/tests/test_widechar_data.cpp
@@ -62,3 +62,55 @@ TEST_CASE("Test SQLBindParameter with WVARCHAR type", "[odbc]") {
 
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
+
+static SQLBIGINT FetchCount(HSTMT hstmt) {
+	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
+	SQLBIGINT count = -1;
+	EXECUTE_AND_CHECK("SQLGetData (count)", hstmt, SQLGetData, hstmt, 1, SQL_C_SBIGINT, &count, sizeof(count), nullptr);
+	return count;
+}
+
+// Regression: the driver must read a bound parameter buffer according to the
+// application C type (APD), not the target SQL type (IPD). Power BI / .NET
+// System.Data.Odbc bind SQL_C_WCHAR (UTF-16) data against a narrow SQL_VARCHAR
+// parameter; before the fix it was read as narrow ("N\0o\0r\0t\0h"), so
+// `WHERE region = ?` matched nothing. The mirror case (SQL_C_CHAR against a wide
+// SQL_WVARCHAR parameter) read a narrow buffer as UTF-16 -> garbage + over-read.
+TEST_CASE("Test SQLBindParameter with mismatched C and SQL types", "[odbc]") {
+	SQLHANDLE env;
+	SQLHANDLE dbc;
+	HSTMT hstmt = SQL_NULL_HSTMT;
+
+	CONNECT_TO_DATABASE(env, dbc);
+	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
+	EXECUTE_AND_CHECK("SQLExecDirect (create)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("CREATE OR REPLACE TABLE param_mix (region VARCHAR)"), SQL_NTS);
+	EXECUTE_AND_CHECK("SQLExecDirect (insert)", hstmt, SQLExecDirect, hstmt,
+	                  ConvertToSQLCHAR("INSERT INTO param_mix VALUES ('North'), ('South')"), SQL_NTS);
+
+	SECTION("SQL_C_WCHAR buffer bound as SQL_VARCHAR") {
+		std::vector<SQLWCHAR> north_utf16 = {0x004E, 0x006F, 0x0072, 0x0074, 0x0068};
+		SQLLEN ind = static_cast<SQLLEN>(north_utf16.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE region = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_VARCHAR, north_utf16.size(), 0, north_utf16.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	SECTION("SQL_C_CHAR buffer bound as SQL_WVARCHAR") {
+		SQLCHAR north_utf8[] = "North";
+		SQLLEN ind = 5;
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE region = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+		                  SQL_WVARCHAR, 5, 0, north_utf8, ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	EXECUTE_AND_CHECK("SQLFreeStmt (HSTMT)", hstmt, SQLFreeStmt, hstmt, SQL_CLOSE);
+	EXECUTE_AND_CHECK("SQLFreeHandle (HSTMT)", hstmt, SQLFreeHandle, SQL_HANDLE_STMT, hstmt);
+	DISCONNECT_FROM_DATABASE(env, dbc);
+}


### PR DESCRIPTION
### The Issue
In PowerBI, using DirectQuery mode does not work properly with string filters, see https://github.com/motherduckdb/duckdb-power-query-connector/issues/32 for example. I reproduced this by creating a string filter and confirmed that all data is filtered out when it is applied.

### The Cause
In `ParameterDescriptor::SetValue`, parameter conversion switches on the IPD (target SQL) type and assumes the buffer's layout matches it. But Power BI binds a wide `SQL_C_WCHAR` buffer against a narrow `SQL_VARCHAR` parameter, so the actual value is nonsensical because we're interpreting UTF-16 as UTF-8 (as far as I understand the code). Hence, the predicates from string-filters match nothing. Note that similar issues might apply to other type matching here as well, but I am still investigating this.

This was verified via an ODBC trace: SQLBindParameter arrives with fCType = SQL_C_WCHAR, fSqlType = SQL_VARCHAR. It reproduces on the driver alone on Windows for 1.4.4.0 until the latest version (1.5.4.1). 

### The Solution
In the `SQL_VARCHAR` branches of SetValue, decode the buffer as UTF-16 if the C type is `SQL_C_WCHAR`. I built this version of the driver and tested it from PowerBI, and can confirm it resolves the filter bug in DirectQuery mode.

Disclaimer: this is my first time looking at the code here. Please verify I haven't missed conventions in the repo or restrictions I am not aware off suggesting this PR shouldn't work, or should be approached differently!