### PR TITLE
Propagate duckdb commit and version to ODBC.yml

### DIFF
--- a/.github/workflows/ODBC.yml
+++ b/.github/workflows/ODBC.yml
@@ -1,13 +1,58 @@
 name: ODBC
 on:
   push:
+    branches-ignore:
+      - 'vendoring-*'
   pull_request:
   workflow_dispatch:
     inputs:
         override_git_describe:
             description: 'Override git describe'
             required: false
+            default: ''
+            type: 'string'
+        git_ref:
+            description: 'Git ref to check out'
+            required: false
+            default: ''
+            type: 'string'
+        skip_tests:
+            description: 'Skip tests'
+            required: false
+            default: 'false'
+            type: 'string'
+        duckdb_sha:
+            description: 'DuckDB SHA for release event tracking'
+            required: false
+            default: ''
+            type: 'string'
+        duckdb_version:
+            description: 'DuckDB version for release event tracking'
+            required: false
+            default: ''
+            type: 'string'
+        pr_number:
+            description: 'Vendoring PR number to merge after successful CI'
+            required: false
+            default: ''
+            type: 'string'
   workflow_call:
+    inputs:
+      override_git_describe:
+        description: 'Override git describe'
+        required: false
+        default: ''
+        type: 'string'
+      git_ref:
+        description: 'Git ref to check out'
+        required: false
+        default: ''
+        type: 'string'
+      skip_tests:
+        description: 'Skip tests'
+        required: false
+        default: 'false'
+        type: 'string'
   repository_dispatch:
 
 env:
@@ -17,6 +62,7 @@ env:
 jobs:
   odbc-linux-amd64:
     name: Linux (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-latest
     env:
       MANYLINUX_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
@@ -102,6 +148,7 @@ jobs:
 
   odbc-linux-aarch64:
     name: Linux (aarch64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-24.04-arm
     needs: odbc-linux-amd64
     env:
@@ -191,6 +238,7 @@ jobs:
 
   odbc-windows-amd64:
     name: Windows (amd64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: windows-latest
     needs: odbc-linux-amd64
     env:
@@ -348,6 +396,7 @@ jobs:
 
   odbc-windows-arm64:
     name: Windows (aarch64)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: windows-11-arm
     needs: odbc-linux-amd64
     env:
@@ -497,6 +546,7 @@ jobs:
 
   odbc-osx-universal:
     name: macOS (Universal)
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: macos-latest
     env:
       GEN: ninja
@@ -586,6 +636,7 @@ jobs:
 
   debug:
     name: Debug Tests
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'vendoring-') }}
     runs-on: ubuntu-22.04
     needs: odbc-linux-amd64
     env:
@@ -685,9 +736,9 @@ jobs:
         working-directory: ./test/tests/dotnet-linux
         run: dotnet run
 
-  odbc-merge-vendoring-pr:
-    name: Merge vendoring PR 
-    if: ${{ github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'pull_request' && github.head_ref == format('vendoring-{0}', github.base_ref) }}
+  odbc-finalize-vendoring:
+    name: Finalize vendoring
+    if: ${{ always() && github.repository == 'duckdb/duckdb-odbc' && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/vendoring-') && inputs.pr_number != '' && inputs.duckdb_sha != '' }}
     needs:
       - odbc-linux-amd64
       - odbc-linux-aarch64
@@ -703,22 +754,45 @@ jobs:
 
       - name: Merge vendoring PR
         id: merge_vendoring_pr
+        if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            echo "Merging PR number: ${{ github.event.pull_request.number }} with message: ${{ github.event.pull_request.title }}"
-            gh pr merge vendoring-${{ github.base_ref }} \
+            BASE_BRANCH=$(gh pr view ${{ inputs.pr_number }} --json baseRefName --jq '.baseRefName')
+            PR_TITLE=$(gh pr view ${{ inputs.pr_number }} --json title --jq '.title')
+            echo "Merging PR number: ${{ inputs.pr_number }} with message: ${PR_TITLE}"
+            gh pr merge ${{ inputs.pr_number }} \
              --rebase \
-             --subject "${{ github.event.pull_request.title }}" \
+             --subject "${PR_TITLE}" \
              --body ""
+            echo "base_branch=${BASE_BRANCH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Record client status
+        if: always()
+        uses: duckdb/duckdb-workflow-trigger/dispatch@main
+        with:
+          github_token: ${{ secrets.DUCKDB_RELEASE_DISPATCH_TOKEN }}
+          event: client_ready
+          client: odbc
+          duckdb_version: ${{ inputs.duckdb_version }}
+          duckdb_commit: ${{ inputs.duckdb_sha }}
+          status: ${{ (contains(needs.*.result, 'failure') || steps.merge_vendoring_pr.outcome == 'failure') && 'failure' || contains(needs.*.result, 'cancelled') && 'cancelled' || contains(needs.*.result, 'skipped') && 'skipped' || 'success' }}
+          message: DuckDB ODBC client ready
 
       - name: Update vendoring branch
         id: update_vendoring_branch
         if: ${{ steps.merge_vendoring_pr.outcome == 'success' }}
+        continue-on-error: true
         run: |
-            # Delete vendoring-${{ github.base_ref }} branch and re-create it for future PRs
-            git push --delete origin vendoring-${{ github.base_ref }}
-            git checkout --track origin/${{ github.base_ref }}
+            BASE_BRANCH="${{ steps.merge_vendoring_pr.outputs.base_branch }}"
+            # Delete vendoring-${BASE_BRANCH} branch and re-create it for future PRs
+            git push --delete origin vendoring-${BASE_BRANCH}
+            git checkout --track origin/${BASE_BRANCH}
             git pull --ff-only
-            git branch vendoring-${{ github.base_ref }}
-            git push origin vendoring-${{ github.base_ref }}
+            git branch vendoring-${BASE_BRANCH}
+            git push origin vendoring-${BASE_BRANCH}
+
+      - name: Fail on unsuccessful final status
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') || steps.merge_vendoring_pr.outcome == 'failure' || steps.update_vendoring_branch.outcome == 'failure') }}
+        run: exit 1

--- a/.github/workflows/Vendor.yml
+++ b/.github/workflows/Vendor.yml
@@ -7,10 +7,20 @@ on:
         required: false
         default: ''
         type: 'string'
+      duckdb-version:
+        description: 'Vendor Specific DuckDB Version'
+        required: false
+        default: ''
+        type: 'string'
   workflow_dispatch:
     inputs:
       duckdb-sha:
         description: 'Vendor Specific DuckDB SHA'
+        required: false
+        default: ''
+        type: 'string'
+      duckdb-version:
+        description: 'Vendor Specific DuckDB Version'
         required: false
         default: ''
         type: 'string'
@@ -20,6 +30,10 @@ jobs:
     name: "Update Vendored Sources"
     if: ${{ github.repository == 'duckdb/duckdb-odbc' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
 
     steps:
       - name: Set up Python
@@ -137,6 +151,8 @@ jobs:
              --base "${{ github.ref_name }}" \
              --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
              --body-file body.txt
+            PR_NUM=$(gh pr list --head vendoring-${{ github.ref_name }} --json number --jq '.[].number')
+            echo "pr_num=${PR_NUM}" >> "${GITHUB_OUTPUT}"
 
       - name: Update PR
         id: update_pr
@@ -156,6 +172,16 @@ jobs:
             gh pr edit ${{ steps.check_pr_exists.outputs.pr_num }} \
              --title "${{ steps.commit_and_push.outputs.commit_msg }}" \
              --body-file body.txt 
-            # Close and re-open the PR to trigger the tests
-            gh pr close ${{ steps.check_pr_exists.outputs.pr_num }}
-            gh pr reopen ${{ steps.check_pr_exists.outputs.pr_num }}
+
+      - name: Dispatch ODBC CI
+        id: dispatch_odbc_ci
+        if: ${{ steps.create_pr.outcome == 'success' || steps.update_pr.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.create_pr.outputs.pr_num || steps.check_pr_exists.outputs.pr_num }}
+        run: |
+            gh workflow run ODBC.yml \
+             --ref vendoring-${{ github.ref_name }} \
+             -f duckdb_sha="${{ inputs.duckdb-sha }}" \
+             -f duckdb_version="${{ inputs.duckdb-version }}" \
+             -f pr_number="${PR_NUM}"


### PR DESCRIPTION
This PR is part of the [alpha](https://github.com/duckdblabs/duckdb-internal/issues/8628) release versions initiative.

The added action sends the release state of the python client back to the [release event system](https://github.com/duckdblabs/duckdb-internal/issues/9742).

See also the release event system [usage](https://github.com/duckdb/duckdb-workflow-trigger/#usage), and a very [similar](https://github.com/duckdb/duckdb-java/pull/749) PR for `duckdb-java`.