### PR TITLE
Decode params by C type for any SQL target (1.5)

### DIFF
--- a/src/odbc_driver/parameter_descriptor.cpp
+++ b/src/odbc_driver/parameter_descriptor.cpp
@@ -261,16 +261,18 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 	// and get the right parameter using the index (now it's working for all supported tests)
 	duckdb::const_data_ptr_t dataptr = (duckdb::const_data_ptr_t)sql_data_ptr;
 
-	switch (ipd->records[rec_idx].sql_desc_type) {
-	case SQL_CHAR:
-	case SQL_VARCHAR:
-	case SQL_LONGVARCHAR: {
+	// Power BI / .NET System.Data.Odbc bind a string buffer (SQL_C_CHAR/SQL_C_WCHAR)
+	// against non-string SQL types - a DECIMAL slicer arrives as "42.00", a DATE filter
+	// as "2024-01-01". Decode by the C (buffer) type and hand DuckDB a string to cast,
+	// rather than reading the buffer as the SQL type's binary layout (which yields
+	// garbage). Binary targets are excluded - their buffers are not text.
+	const auto sql_type = ipd->records[rec_idx].sql_desc_type;
+	const auto c_type = apd_record->sql_desc_type;
+	const bool binary_target = sql_type == SQL_BINARY || sql_type == SQL_VARBINARY || sql_type == SQL_LONGVARBINARY;
+	if (!binary_target && (c_type == SQL_C_CHAR || c_type == SQL_C_WCHAR)) {
 		auto buff_size = duckdb::MaxValue((SQLLEN)ipd->records[rec_idx].sql_desc_length,
 		                                  apd->records[rec_idx].sql_desc_octet_length);
-		// Clients such as Power BI / .NET System.Data.Odbc bind SQL_C_WCHAR (UTF-16)
-		// data against a narrow SQL_VARCHAR parameter - Decode it as UTF-16 based on
-		// the C type instead, following the SQL_WCHAR case below.
-		if (apd_record->sql_desc_type == SQL_C_WCHAR) {
+		if (c_type == SQL_C_WCHAR) {
 			auto utf16_data = (SQLWCHAR *)sql_data_ptr + (val_idx * buff_size);
 			if (*sql_ind_ptr_val_set == SQL_NTS) {
 				*sql_ind_ptr_val_set =
@@ -279,8 +281,24 @@ SQLRETURN ParameterDescriptor::SetValue(idx_t rec_idx) {
 			auto utf16_len = static_cast<size_t>(*sql_ind_ptr_val_set / sizeof(SQLWCHAR));
 			auto utf8_vec = duckdb::widechar::utf16_to_utf8_lenient(utf16_data, utf16_len);
 			value = Value(std::string(reinterpret_cast<char *>(utf8_vec.data()), utf8_vec.size()));
-			break;
+		} else {
+			auto str_data = (char *)sql_data_ptr + (val_idx * buff_size);
+			if (*sql_ind_ptr_val_set == SQL_NTS) {
+				*sql_ind_ptr_val_set = strlen(str_data);
+			}
+			value = Value(
+			    duckdb::OdbcUtils::ConvertSQLCHARToString(reinterpret_cast<SQLCHAR *>(str_data), *sql_ind_ptr_val_set));
 		}
+		SetValue(value, rec_idx);
+		return SQL_PARAM_SUCCESS;
+	}
+
+	switch (sql_type) {
+	case SQL_CHAR:
+	case SQL_VARCHAR:
+	case SQL_LONGVARCHAR: {
+		auto buff_size = duckdb::MaxValue((SQLLEN)ipd->records[rec_idx].sql_desc_length,
+		                                  apd->records[rec_idx].sql_desc_octet_length);
 		auto str_data = (char *)sql_data_ptr + (val_idx * buff_size);
 		if (*sql_ind_ptr_val_set == SQL_NTS) {
 			*sql_ind_ptr_val_set = strlen(str_data);

--- a/test/tests/test_widechar_data.cpp
+++ b/test/tests/test_widechar_data.cpp
@@ -63,6 +63,11 @@ TEST_CASE("Test SQLBindParameter with WVARCHAR type", "[odbc]") {
 	DISCONNECT_FROM_DATABASE(env, dbc);
 }
 
+// ASCII -> UTF-16, for building SQL_C_WCHAR parameter buffers in tests.
+static std::vector<SQLWCHAR> Widen(const std::string &s) {
+	return std::vector<SQLWCHAR>(s.begin(), s.end());
+}
+
 static SQLBIGINT FetchCount(HSTMT hstmt) {
 	EXECUTE_AND_CHECK("SQLFetch", hstmt, SQLFetch, hstmt);
 	SQLBIGINT count = -1;
@@ -78,17 +83,106 @@ TEST_CASE("Test SQLBindParameter with mismatched C and SQL types", "[odbc]") {
 	CONNECT_TO_DATABASE(env, dbc);
 	EXECUTE_AND_CHECK("SQLAllocHandle (HSTMT)", hstmt, SQLAllocHandle, SQL_HANDLE_STMT, dbc, &hstmt);
 	EXECUTE_AND_CHECK("SQLExecDirect (create)", hstmt, SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("CREATE OR REPLACE TABLE param_mix (region VARCHAR)"), SQL_NTS);
+	                  ConvertToSQLCHAR("CREATE OR REPLACE TABLE param_mix (region VARCHAR, amount DECIMAL(10,2), "
+	                                   "d DATE, ts TIMESTAMP, tm TIME, flag BOOLEAN, big HUGEINT)"),
+	                  SQL_NTS);
 	EXECUTE_AND_CHECK("SQLExecDirect (insert)", hstmt, SQLExecDirect, hstmt,
-	                  ConvertToSQLCHAR("INSERT INTO param_mix VALUES ('North'), ('South')"), SQL_NTS);
+	                  ConvertToSQLCHAR("INSERT INTO param_mix VALUES "
+	                                   "('North', 42.00, DATE '2024-01-01', TIMESTAMP '2024-01-01 12:34:56', "
+	                                   "TIME '12:34:56', true, 123456789012345678901234567890), "
+	                                   "('South', 7.50, DATE '2024-02-02', TIMESTAMP '2024-02-02 01:02:03', "
+	                                   "TIME '01:02:03', false, 1)"),
+	                  SQL_NTS);
 
 	SECTION("SQL_C_WCHAR buffer bound as SQL_VARCHAR") {
-		std::vector<SQLWCHAR> north_utf16 = {0x004E, 0x006F, 0x0072, 0x0074, 0x0068};
-		SQLLEN ind = static_cast<SQLLEN>(north_utf16.size() * sizeof(SQLWCHAR));
+		auto buf = Widen("North");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
 		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
 		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE region = ?"), SQL_NTS);
 		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
-		                  SQL_VARCHAR, north_utf16.size(), 0, north_utf16.data(), ind, &ind);
+		                  SQL_VARCHAR, buf.size(), 0, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	// A DECIMAL slicer arrives from Power BI as a text buffer bound against SQL_DECIMAL.
+	SECTION("SQL_C_WCHAR buffer bound as SQL_DECIMAL") {
+		auto buf = Widen("42.00");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE amount = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_DECIMAL, 10, 2, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	// Same path via a narrow SQL_C_CHAR buffer.
+	SECTION("SQL_C_CHAR buffer bound as SQL_DECIMAL") {
+		std::string s = "42.00";
+		SQLLEN ind = static_cast<SQLLEN>(s.size());
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE amount = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_CHAR,
+		                  SQL_DECIMAL, 10, 2, (SQLPOINTER)s.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	// A DATE filter arrives as text bound against SQL_TYPE_DATE.
+	SECTION("SQL_C_WCHAR buffer bound as SQL_TYPE_DATE") {
+		auto buf = Widen("2024-01-01");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE d = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_TYPE_DATE, 10, 0, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	SECTION("SQL_C_WCHAR buffer bound as SQL_TYPE_TIMESTAMP") {
+		auto buf = Widen("2024-01-01 12:34:56");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE ts = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_TYPE_TIMESTAMP, 23, 3, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	SECTION("SQL_C_WCHAR buffer bound as SQL_TYPE_TIME") {
+		auto buf = Widen("12:34:56");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE tm = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_TYPE_TIME, 8, 0, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	// Boolean: DuckDB casts the text 'true' to BOOLEAN for the comparison.
+	SECTION("SQL_C_WCHAR buffer bound as SQL_BIT (boolean)") {
+		auto buf = Widen("true");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE flag = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR, SQL_BIT,
+		                  5, 0, buf.data(), ind, &ind);
+		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
+		REQUIRE(FetchCount(hstmt) == 1);
+	}
+
+	// HUGEINT exceeds 64 bits; binding it as text is the only way it round-trips.
+	SECTION("SQL_C_WCHAR buffer bound as SQL_NUMERIC (hugeint)") {
+		auto buf = Widen("123456789012345678901234567890");
+		SQLLEN ind = static_cast<SQLLEN>(buf.size() * sizeof(SQLWCHAR));
+		EXECUTE_AND_CHECK("SQLPrepare", hstmt, SQLPrepare, hstmt,
+		                  ConvertToSQLCHAR("SELECT count(*) FROM param_mix WHERE big = ?"), SQL_NTS);
+		EXECUTE_AND_CHECK("SQLBindParameter", hstmt, SQLBindParameter, hstmt, 1, SQL_PARAM_INPUT, SQL_C_WCHAR,
+		                  SQL_NUMERIC, 30, 0, buf.data(), ind, &ind);
 		EXECUTE_AND_CHECK("SQLExecute", hstmt, SQLExecute, hstmt);
 		REQUIRE(FetchCount(hstmt) == 1);
 	}


### PR DESCRIPTION
This is a backport of the PR #494 to `v1.5-variegata` stable branch.

Power BI / .NET System.Data.Odbc bind SQL_C_CHAR/SQL_C_WCHAR buffers against non-string SQL types (DECIMAL slicers, DATE filters). SetValue read the buffer by the IPD SQL type, so a '42.00' / '2024-01-01' text buffer was reinterpreted as a numeric/date binary layout and produced garbage.

Decode by the C type up front and let DuckDB cast the string; drop the narrow SQL_C_WCHAR->SQL_VARCHAR special case it supersedes.

Tests cover WCHAR/CHAR text bound against DECIMAL, DATE, TIMESTAMP, TIME, BOOLEAN and HUGEINT targets.